### PR TITLE
Fix LevyFlightEpisodic to support SearchingOccurrencesReporting

### DIFF
--- a/multi-setting-runner.py
+++ b/multi-setting-runner.py
@@ -29,7 +29,7 @@ default_lfe_config = ".\\settings\\skripsi\\randomsearch-lf-episodic.cfg"
 lfepisodic_template = (
     ".\\one.bat -b 1 "
     "-d Report.reportDir=reports/skripsi/lf-episodic/run-id/IDENTIFIER/ep/EP"
-    "@@Report.persistencePath=reports/skripsi/lf-episodic/run-id/IDENTIFIER/_persistence.json"
+    "@@EpisodicPersistenceManager.persistencePath=reports/skripsi/lf-episodic/run-id/IDENTIFIER/_persistence.json"
     "@@EpisodicPersistenceManager.episodeNumber=EP "
     f"{default_lfe_config}"
 )

--- a/settings/skripsi/randomsearch-lf-episodic.cfg
+++ b/settings/skripsi/randomsearch-lf-episodic.cfg
@@ -13,13 +13,9 @@ Scenario.nrofHostGroups = 2
 #===========================================================================
 # INTERFACE SPECIFIC SETTINGS
 #===========================================================================
-targetInterface.type = SimpleBroadcastInterface
-targetInterface.transmitSpeed = 10M
-targetInterface.transmitRange = 10
-
-agentInterface.type = SimpleBroadcastInterface
-agentInterface.transmitSpeed = 10M
-agentInterface.transmitRange = 10
+highspeedInterface.type = SimpleBroadcastInterface
+highspeedInterface.transmitSpeed = 10M
+highspeedInterface.transmitRange = 10
 
 #===========================================================================
 # GROUP SPECIFIC SETTINGS
@@ -44,6 +40,7 @@ Group.waitTime = 0, 0
 Group.speed = 0.5, 0.5
 # Group.msgTtl = 300
 Group.nrofHosts = 101
+Group.interface1 = highspeedInterface
 
 [ Stationary Clustered Movement ]
 Group.alpha = 0.5
@@ -59,7 +56,6 @@ Group1.groupID = A
 Group1.nrofHosts = 1
 Group1.router = DecisionEngineRouter
 Group1.movementModel = LevyFlightEpisodic
-Group1.interface1 = agentInterface
 
 [ Group 2: Target Nodes ]
 Group2.groupID = T
@@ -69,7 +65,6 @@ Group2.cluster = 10, 10
 Group2.sigma = 25.0, 50.0
 Group2.nrofHosts = 100
 Group2.transmitRange = 10
-Group2.interface1 = targetInterface
 
 # [ Group 3 ]
 # Group3.groupID = C

--- a/src/movement/LevyFlightEpisodic.java
+++ b/src/movement/LevyFlightEpisodic.java
@@ -31,22 +31,30 @@ public class LevyFlightEpisodic extends MovementModel implements TrajectoryFrequ
 	/**
 	 * Controls how heavy the distribution tail is
 	 */
-	public static final String ALPHA = "levyAlpha";
+	public static final String ALPHA_S = "levyAlpha";
+	public static final String XM_S = "xm";
+	public static final String TARGET_PREFIX_S = "targetPrefix";
+
 	public static final double DEFAULT_ALPHA = 1.5;
-
-	public static final String XM = "xm";
 	public static final double DEFAULT_XM = 1;
+	public static final String DEFAULT_TARGET_PREFIX = "T";
 
-	private double xm, alpha;
+	private final double xm;
+	private final double alpha;
+	/**
+	 * The target's prefix
+	 */
+	private String targetPrefix;
 
-	public LevyFlightEpisodic(Settings settings) {
-		super(settings);
+	public LevyFlightEpisodic(Settings s) {
+		super(s);
 
 		this.trajectoryFrequencies = new HashMap<>();
 
-		this.alpha = settings.contains(ALPHA) ? settings.getDouble(ALPHA) : DEFAULT_ALPHA;
-		this.xm = settings.contains(XM) ? settings.getDouble(XM) : DEFAULT_XM;
-		
+		this.targetPrefix = s.getSetting(TARGET_PREFIX_S, DEFAULT_TARGET_PREFIX);
+		this.alpha = s.getDouble(ALPHA_S, DEFAULT_ALPHA);
+		this.xm = s.getDouble(XM_S, DEFAULT_XM);
+
 		// Re/Initializes episodic persistence
 		EpisodicPersistenceData epd = EpisodicPersistenceManager.loadIfExists();
 		if (epd != null) {
@@ -61,6 +69,7 @@ public class LevyFlightEpisodic extends MovementModel implements TrajectoryFrequ
 
 		this.xm = lf.xm;
 		this.alpha = lf.alpha;
+		this.targetPrefix = lf.targetPrefix;
 	}
 
 	/**

--- a/src/movement/LevyFlightEpisodic.java
+++ b/src/movement/LevyFlightEpisodic.java
@@ -160,7 +160,7 @@ public class LevyFlightEpisodic extends MovementModel implements TrajectoryFrequ
 
 	@Override
 	public void saveTo(EpisodicPersistenceData epd) {
-		System.out.printf("<%s> Saving persistence data...%n", QLearningMovement.class.getName());
+		System.out.printf("[%s] Saving persistence data...%n", LevyFlightEpisodic.class.getName());
 
 		/* Saving trajectory recorder */
 		epd.trajectoryFrequencies = new HashMap<>();
@@ -171,7 +171,7 @@ public class LevyFlightEpisodic extends MovementModel implements TrajectoryFrequ
 
 	@Override
 	public void loadFrom(EpisodicPersistenceData epd) {
-		System.out.printf("<%s> Loading persistence data...%n", QLearningMovement.class.getName());
+		System.out.printf("[%s] Loading persistence data...%n", LevyFlightEpisodic.class.getName());
 
 		/* Loading trajectory recorder */
 		trajectoryFrequencies.clear();

--- a/src/movement/LevyFlightEpisodic.java
+++ b/src/movement/LevyFlightEpisodic.java
@@ -1,11 +1,13 @@
 package movement;
 
+import core.Connection;
 import core.Coord;
+import core.DTNHost;
 import core.Settings;
-import movement.rl.QLearningMovement;
 import movement.rl.persistence.EpisodicPersistable;
 import movement.rl.persistence.EpisodicPersistenceData;
 import movement.rl.persistence.EpisodicPersistenceManager;
+import report.SearchingOccurrencesReporting;
 import report.TrajectoryFrequencyReporting;
 
 import java.util.HashMap;
@@ -18,9 +20,12 @@ import java.util.Map;
  * @see <a href="https://en.wikipedia.org/wiki/L%C3%A9vy_flight">Lévy flight</a>
  * @see <a href="https://ieeexplore.ieee.org/document/5750071">On the Levy-Walk Nature of Human Mobility</a>
  */
-public class LevyFlightEpisodic extends MovementModel implements TrajectoryFrequencyReporting, EpisodicPersistable {
+public class LevyFlightEpisodic extends MovementModel implements EpisodicPersistable, TrajectoryFrequencyReporting, SearchingOccurrencesReporting {
 	// [ REPORTING VARIABLES ]
 	private final Map<Integer, Integer> trajectoryFrequencies;
+
+	private int currentCumulativeTrueDetections;
+	private int currentTrueDetections;
 
 	/**
 	 * Number of waypoints per path
@@ -50,6 +55,8 @@ public class LevyFlightEpisodic extends MovementModel implements TrajectoryFrequ
 		super(s);
 
 		this.trajectoryFrequencies = new HashMap<>();
+		currentCumulativeTrueDetections = 0;
+		currentTrueDetections = 0;
 
 		this.targetPrefix = s.getSetting(TARGET_PREFIX_S, DEFAULT_TARGET_PREFIX);
 		this.alpha = s.getDouble(ALPHA_S, DEFAULT_ALPHA);
@@ -66,10 +73,27 @@ public class LevyFlightEpisodic extends MovementModel implements TrajectoryFrequ
 		super(lf);
 
 		this.trajectoryFrequencies = lf.trajectoryFrequencies;
+		this.currentCumulativeTrueDetections = lf.currentCumulativeTrueDetections;
+		this.currentTrueDetections = lf.currentTrueDetections;
 
 		this.xm = lf.xm;
 		this.alpha = lf.alpha;
 		this.targetPrefix = lf.targetPrefix;
+	}
+
+	@Override
+	public void changedConnection(Connection con) {
+		if (con.isUp()) {
+			// The host
+			DTNHost otherNode = con.getOtherNode(getHost());
+			if (otherNode != null && !otherNode.getGroupId().equals(getHost().getGroupId())) {
+				// Check if the other node matches target prefix
+				if (otherNode.getGroupId().startsWith(targetPrefix)) {
+					// Increment the cumulative detection
+					currentTrueDetections++;
+				}
+			}
+		}
 	}
 
 	/**
@@ -157,6 +181,11 @@ public class LevyFlightEpisodic extends MovementModel implements TrajectoryFrequ
 		return trajectoryFrequencies;
 	}
 
+	@Override
+	public int retrieveTrueDetections() {
+		return currentTrueDetections;
+	}
+
 	/**
 	 * Minimizes the process of saving an episode.
 	 */
@@ -176,11 +205,16 @@ public class LevyFlightEpisodic extends MovementModel implements TrajectoryFrequ
 		for (var entry : trajectoryFrequencies.entrySet()) {
 			epd.trajectoryFrequencies.put(String.valueOf(entry.getKey()), entry.getValue());
 		}
+
+		/* Saving Total occurrences recorder */
+		epd.previousCumulativeTrueDetections = this.currentCumulativeTrueDetections;
+		epd.currentCumulativeTrueDetections = this.currentCumulativeTrueDetections + currentTrueDetections;
+		epd.currentTrueDetections = currentTrueDetections;
 	}
 
 	@Override
 	public void loadFrom(EpisodicPersistenceData epd) {
-		System.out.printf("[%s] Loading persistence data...%n", LevyFlightEpisodic.class.getName());
+		System.out.printf("[%s] Loading persistence data...%n", this.getClass().getName());
 
 		/* Loading trajectory recorder */
 		trajectoryFrequencies.clear();
@@ -189,5 +223,9 @@ public class LevyFlightEpisodic extends MovementModel implements TrajectoryFrequ
 				this.trajectoryFrequencies.put(Integer.valueOf(entry.getKey()), entry.getValue());
 			}
 		}
+
+		/* Loading Total occurrences recorder */
+		System.out.printf("[%s] Reading EPD.currentCumulativeTrueDetections: " + epd.currentCumulativeTrueDetections, this.getClass().getName());
+		this.currentCumulativeTrueDetections = epd.currentCumulativeTrueDetections;
 	}
 }

--- a/src/routing/SearchingAgentRouter.java
+++ b/src/routing/SearchingAgentRouter.java
@@ -96,7 +96,7 @@ public class SearchingAgentRouter implements RoutingDecisionEngine, SearchingAge
 			return;
 		}
 		if (targetMovement != null && targetMovement.getClass().isInstance(peer.getMovement())) {
-			System.out.println("FOUND HOST MOV: " + peer.getName());
+//			System.out.println("FOUND HOST MOV: " + peer.getName());
 			if (initialDiscovery == 0) {
 				initialDiscovery = SimClock.getTime();
 			}
@@ -110,7 +110,7 @@ public class SearchingAgentRouter implements RoutingDecisionEngine, SearchingAge
 //            encounteredSearchables.add(peer);
 //        }
 		else if (peer.getName().startsWith(targetPrefix)) {
-			System.out.println("FOUND HOST PRE: " + peer.getName());
+//			System.out.println("FOUND HOST PRE: " + peer.getName());
 			if (initialDiscovery == 0) {
 				initialDiscovery = SimClock.getTime();
 			}


### PR DESCRIPTION
Changes made:
- Restructured variable initializations and instantiations
- Added reporting variables and saves it as per [EpisodicPersistenceData.java](https://github.com/vianneynara/onesim-rl/blob/feat/34-fix-levyflightepisodic-to-support-searchingoccurrencereporter/src/movement/rl/persistence/EpisodicPersistenceData.java) for [SearchingOccurrencesReporting.java](https://github.com/vianneynara/onesim-rl/blob/feat/34-fix-levyflightepisodic-to-support-searchingoccurrencereporter/src/report/SearchingOccurrencesReporting.java).
- Implement [SearchingOccurrencesReporting.java](https://github.com/vianneynara/onesim-rl/blob/feat/34-fix-levyflightepisodic-to-support-searchingoccurrencereporter/src/report/SearchingOccurrencesReporting.java) methods
- Properly set [randomsearch-lf-episodic.cfg](https://github.com/vianneynara/onesim-rl/blob/feat/34-fix-levyflightepisodic-to-support-searchingoccurrencereporter/settings/skripsi/randomsearch-lf-episodic.cfg) (the configuration file) for persistence use and standardized the persistence path foldering.

Now the episodic Levy Flight movement solves #34 for changing environment searching with cumulative targets found reports.