### PR TITLE
Use fixed movement name instead

### DIFF
--- a/settings/skripsi/randomsearch-qlearn.cfg
+++ b/settings/skripsi/randomsearch-qlearn.cfg
@@ -2,7 +2,7 @@
 # SCENARIO CONFIGURATION
 #===========================================================================
 [ Scenario ]
-Scenario.name = RandomSearch-amm@%%Group1.movementModel%%-tmm@%%Group2.movementModel%%-rlbp@%%QLearningMovement.behaviorPolicy%%-episode@%%EpisodicPersistenceManager.episodeNumber%%
+Scenario.name = RandomSearch-amm@QLearningMovement-tmm@StationaryGaussian-rlbp@%%QLearningMovement.behaviorPolicy%%-episode@%%EpisodicPersistenceManager.episodeNumber%%
 Scenario.simulateConnections = true
 Scenario.updateInterval = 1
 # 700k seconds (~8.1 days)


### PR DESCRIPTION
Took 34 minutes, shorten the packages call, use fixed movement instead. Resolves #44 