### PR TITLE
Separate MovementModel RNG and RL learning RNG

### DIFF
--- a/batch_runner.py
+++ b/batch_runner.py
@@ -202,7 +202,8 @@ def build_result_id_dir(alg: str, runs: int, bp: str = None, overrides: list[str
 def run_script(algo: str, overrides_string: str = None, ep: int = -1) -> bool:
     script = [
         r".\one.bat",
-        "-b", "1",
+        "-b",
+        "1",
     ]
 
     # Add overrides only if provided

--- a/settings/skripsi/randomsearch-qlearn.cfg
+++ b/settings/skripsi/randomsearch-qlearn.cfg
@@ -102,6 +102,7 @@ QLearningMovement.foundReward = 10
 QLearningMovement.agentSpeed = 3
 # 1 minutes sim time target regeneration period
 QLearningMovement.targetCooldown = 3600
+QLearningMovement.learningSeed = 0
 
 [ EpsilonGreedyBehavior settings ]
 BehaviorPolicy.EpsilonGreedy.epsilon = 1

--- a/settings/skripsi/randomsearch-qlearn.cfg
+++ b/settings/skripsi/randomsearch-qlearn.cfg
@@ -102,7 +102,7 @@ QLearningMovement.foundReward = 10
 QLearningMovement.agentSpeed = 3
 # 1 minutes sim time target regeneration period
 QLearningMovement.targetCooldown = 3600
-QLearningMovement.learningSeed = 0
+QLearningMovement.learningSeed = 2
 
 [ EpsilonGreedyBehavior settings ]
 BehaviorPolicy.EpsilonGreedy.epsilon = 1
@@ -130,7 +130,7 @@ EpisodicPersistenceManager.saveEpisodically = true
 [ Movement model settings ]
 # seed for movement models' pseudo random number generator
 #MovementModel.rngSeed = [2, 8372, 98092, 18293, 777]
-MovementModel.rngSeed = 0
+MovementModel.rngSeed = 1
 # World's size (width, height; meters)
 MovementModel.worldSize = 750, 750
 # Warmup period (seconds)

--- a/src/core/Coord.java
+++ b/src/core/Coord.java
@@ -1,6 +1,6 @@
-/* 
+/*
  * Copyright 2010 Aalto University, ComNet
- * Released under GPLv3. See LICENSE.txt for details. 
+ * Released under GPLv3. See LICENSE.txt for details.
  */
 package core;
 
@@ -20,35 +20,39 @@ public class Coord implements Cloneable, Comparable<Coord> {
 
 	/**
 	 * Constructor.
+	 *
 	 * @param x Initial X-coordinate
 	 * @param y Initial Y-coordinate
 	 */
 	public Coord(double x, double y) {
-		setLocation(x,y);
+		setLocation(x, y);
 	}
-	
+
 	/**
 	 * Sets the location of this coordinate object
+	 *
 	 * @param x The x coordinate to set
 	 * @param y The y coordinate to set
 	 */
 	public void setLocation(double x, double y) {
 		this.x = x;
-		this.y = y;		
+		this.y = y;
 	}
-	
+
 	/**
 	 * Sets this coordinate's location to be equal to other
 	 * coordinates location
+	 *
 	 * @param c The other coordinate
 	 */
 	public void setLocation(Coord c) {
 		this.x = c.x;
-		this.y = c.y;		
+		this.y = c.y;
 	}
-	
+
 	/**
 	 * Moves the point by dx and dy
+	 *
 	 * @param dx How much to move the point in X-direction
 	 * @param dy How much to move the point in Y-direction
 	 */
@@ -56,21 +60,23 @@ public class Coord implements Cloneable, Comparable<Coord> {
 		this.x += dx;
 		this.y += dy;
 	}
-	
+
 	/**
 	 * Returns the distance to another coordinate
+	 *
 	 * @param other The other coordinate
 	 * @return The distance between this and another coordinate
 	 */
 	public double distance(Coord other) {
 		double dx = this.x - other.x;
 		double dy = this.y - other.y;
-		
-		return Math.sqrt(dx*dx + dy*dy);
+
+		return Math.sqrt(dx * dx + dy * dy);
 	}
-	
+
 	/**
 	 * Returns the x coordinate
+	 *
 	 * @return x coordinate
 	 */
 	public double getX() {
@@ -79,20 +85,22 @@ public class Coord implements Cloneable, Comparable<Coord> {
 
 	/**
 	 * Returns the y coordinate
+	 *
 	 * @return y coordinate
-	 */	
+	 */
 	public double getY() {
 		return this.y;
 	}
-	
+
 	/**
 	 * Returns a text representation of the coordinate (rounded to 2 decimals)
+	 *
 	 * @return a text representation of the coordinate
 	 */
 	public String toString() {
-		return String.format("(%.2f,%.2f)",x,y);
+		return String.format("(%.2f,%.2f)", x, y);
 	}
-	
+
 	/**
 	 * Returns a clone of this coordinate
 	 */
@@ -106,17 +114,17 @@ public class Coord implements Cloneable, Comparable<Coord> {
 		}
 		return clone;
 	}
-	
+
 	/**
 	 * Checks if this coordinate's location is equal to other coordinate's
+	 *
 	 * @param c The other coordinate
 	 * @return True if locations are the same
 	 */
 	public boolean equals(Coord c) {
 		if (c == this) {
 			return true;
-		}
-		else {
+		} else {
 			return (x == c.x && y == c.y);
 		}
 	}
@@ -131,38 +139,36 @@ public class Coord implements Cloneable, Comparable<Coord> {
 	 * (actually a hash of the String made of the coordinates)
 	 */
 	public int hashCode() {
-		return (x+","+y).hashCode();
+		return (x + "," + y).hashCode();
 	}
 
 	/**
 	 * Compares this coordinate to other coordinate. Coordinate whose y
 	 * value is smaller comes first and if y values are equal, the one with
 	 * smaller x value comes first.
+	 *
 	 * @return -1, 0 or 1 if this node is before, in the same place or
 	 * after the other coordinate
 	 */
 	public int compareTo(Coord other) {
 		if (this.y < other.y) {
 			return -1;
-		}
-		else if (this.y > other.y) {
+		} else if (this.y > other.y) {
 			return 1;
-		}
-		else if (this.x < other.x) {
+		} else if (this.x < other.x) {
 			return -1;
-		}
-		else if (this.x > other.x) {
+		} else if (this.x > other.x) {
 			return 1;
-		}
-		else {
+		} else {
 			return 0;
 		}
 	}
 
 	/**
 	 * Checks whether two coordinates are close enough to be considered close.
-	 * @param c1 First coordinate
-	 * @param c2 Second coordinate
+	 *
+	 * @param c1    First coordinate
+	 * @param c2    Second coordinate
 	 * @param range The range the coordinates are considered close
 	 * @return boolean
 	 */

--- a/src/core/Coord.java
+++ b/src/core/Coord.java
@@ -4,17 +4,26 @@
  */
 package core;
 
+import lombok.Setter;
+
 /**
  * Class to hold 2D coordinates and perform simple arithmetics and
  * transformations
  */
 public class Coord implements Cloneable, Comparable<Coord> {
+	@Setter
 	private double x;
+	@Setter
 	private double y;
 
 	/** No argument constructor, used for fastjson to properly deserialize. */
 	public Coord() {
 		this(0, 0);
+	}
+
+	/** Copy constructor. */
+	public Coord(Coord other) {
+		this(other.x, other.y);
 	}
 
 

--- a/src/core/Coord.java
+++ b/src/core/Coord.java
@@ -11,7 +11,13 @@ package core;
 public class Coord implements Cloneable, Comparable<Coord> {
 	private double x;
 	private double y;
-	
+
+	/** No argument constructor, used for fastjson to properly deserialize. */
+	public Coord() {
+		this(0, 0);
+	}
+
+
 	/**
 	 * Constructor.
 	 * @param x Initial X-coordinate

--- a/src/movement/rl/QLearningMovement.java
+++ b/src/movement/rl/QLearningMovement.java
@@ -129,26 +129,17 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 	 * we need the same locations of the targets per episode instead of position re-initialization per episode.
 	 *
 	 */
-	private final Random learningRNG;
+	public static Random learningRNG;
+
+	// static initialization of all movement models' random number generator
+	static {
+		DTNSim.registerForReset(QLearningMovement.class.getCanonicalName());
+		reset();
+	}
 
 	public QLearningMovement(Settings settings) {
 		super(settings);
 		Settings s = new Settings(QLEARNING_NS);
-
-		/* Initialize seed if not 0, initialize random seed if 0, inherit if not specified. */
-		if (s.contains(LEARNING_SEED_S) && s.getInt(LEARNING_SEED_S) != 0) {
-			this.learningRNG = new Random(s.getInt(LEARNING_SEED_S));
-		} else if (s.contains(LEARNING_SEED_S) && s.getInt(LEARNING_SEED_S) == 0) {
-			this.learningRNG = new Random();
-		} else {
-			// Inherit the seed from MovementModel
-			Settings movementSettings = new Settings(MOVEMENT_MODEL_NS);
-			if (movementSettings.contains(RNG_SEED) && movementSettings.getInt(RNG_SEED) != 0) {
-				this.learningRNG = new Random(movementSettings.getInt(RNG_SEED));
-			} else {
-				this.learningRNG = new Random();  // truly random if not set
-			}
-		}
 
 		this.trajectoryFrequencies = new HashMap<>();
 		this.currentCumulativeReward = 0.0;
@@ -249,6 +240,28 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 		this.currentTrajectorySteps = proto.currentTrajectorySteps;
 		this.direction = proto.direction;
 		this.currentPosition = proto.currentPosition;
+	}
+
+	/**
+	 * Resets all static fields to default values
+	 */
+	public static void reset() {
+		Settings s = new Settings(QLEARNING_NS);
+
+		/* Initialize seed if not 0, initialize random seed if 0, inherit if not specified. */
+		if (s.contains(LEARNING_SEED_S) && s.getInt(LEARNING_SEED_S) != 0) {
+			learningRNG = new Random(s.getInt(LEARNING_SEED_S));
+		} else if (s.contains(LEARNING_SEED_S) && s.getInt(LEARNING_SEED_S) == 0) {
+			learningRNG = new Random();
+		} else {
+			// Inherit the seed from MovementModel
+			Settings movementSettings = new Settings(MOVEMENT_MODEL_NS);
+			if (movementSettings.contains(RNG_SEED) && movementSettings.getInt(RNG_SEED) != 0) {
+				learningRNG = new Random(movementSettings.getInt(RNG_SEED));
+			} else {
+				learningRNG = new Random();  // truly random if not set
+			}
+		}
 	}
 
 	protected int selectAction(int state, Set<Integer> availableActions) {

--- a/src/movement/rl/QLearningMovement.java
+++ b/src/movement/rl/QLearningMovement.java
@@ -160,6 +160,8 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 		String behaviorClassName = s.getSetting(BEHAVIOR_POLICY_S, "movement.rl.behavior.EpsilonGreedyBehavior");
 //		System.out.println("is it loading this");
 		this.behaviorPolicy = (BehaviorPolicy) s.createIntializedObject(behaviorClassName);
+		this.behaviorPolicy.setRandom(learningRNG);
+
 		this.targetPrefix = s.getSetting(TARGET_PREFIX_S, "T");
 		this.agentSpeed = s.getDouble(SPEED_S, 1.0);
 		this.targetCooldown = s.getDouble(TARGET_COOLDOWN_S, 0.0);

--- a/src/movement/rl/QLearningMovement.java
+++ b/src/movement/rl/QLearningMovement.java
@@ -218,8 +218,6 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 	 */
 	public QLearningMovement(QLearningMovement proto) {
 		super(proto);
-		this.learningRNG = proto.learningRNG;
-
 		this.trajectoryFrequencies = new HashMap<>(proto.trajectoryFrequencies);
 		this.currentCumulativeReward = proto.currentCumulativeReward;
 		this.currentEpisodeReward = proto.currentEpisodeReward;

--- a/src/movement/rl/QLearningMovement.java
+++ b/src/movement/rl/QLearningMovement.java
@@ -67,6 +67,7 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 	public static final String FOUND_REWARD_S = "foundReward";
 	public static final String SPEED_S = "agentSpeed";
 	public static final String TARGET_COOLDOWN_S = "targetCooldown";
+	public static final String LEARNING_SEED_S = "learningSeed";
 
 	// [Configuration - Fixed parameters]
 	private final double agentSpeed;
@@ -122,9 +123,32 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 	 */
 	private double direction;
 
+	/**
+	 * An addition to separate learning RNG (used in behavior policy), to create differentiation between
+	 * RNG used to initialize locations of the target nodes and the learning behavior. Especially when
+	 * we need the same locations of the targets per episode instead of position re-initialization per episode.
+	 *
+	 */
+	private final Random learningRNG;
+
 	public QLearningMovement(Settings settings) {
 		super(settings);
 		Settings s = new Settings(QLEARNING_NS);
+
+		/* Initialize seed if not 0, initialize random seed if 0, inherit if not specified. */
+		if (s.contains(LEARNING_SEED_S) && s.getInt(LEARNING_SEED_S) != 0) {
+			this.learningRNG = new Random(s.getInt(LEARNING_SEED_S));
+		} else if (s.contains(LEARNING_SEED_S) && s.getInt(LEARNING_SEED_S) == 0) {
+			this.learningRNG = new Random();
+		} else {
+			// Inherit the seed from MovementModel
+			Settings movementSettings = new Settings(MOVEMENT_MODEL_NS);
+			if (movementSettings.contains(RNG_SEED) && movementSettings.getInt(RNG_SEED) != 0) {
+				this.learningRNG = new Random(movementSettings.getInt(RNG_SEED));
+			} else {
+				this.learningRNG = new Random();  // truly random if not set
+			}
+		}
 
 		this.trajectoryFrequencies = new HashMap<>();
 		this.currentCumulativeReward = 0.0;
@@ -201,6 +225,8 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 	 */
 	public QLearningMovement(QLearningMovement proto) {
 		super(proto);
+		this.learningRNG = proto.learningRNG;
+
 		this.trajectoryFrequencies = new HashMap<>(proto.trajectoryFrequencies);
 		this.currentCumulativeReward = proto.currentCumulativeReward;
 		this.currentEpisodeReward = proto.currentEpisodeReward;

--- a/src/movement/rl/QLearningMovement.java
+++ b/src/movement/rl/QLearningMovement.java
@@ -250,11 +250,14 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 
 		/* Initialize seed if not 0, initialize random seed if 0, inherit if not specified. */
 		if (s.contains(LEARNING_SEED_S) && s.getInt(LEARNING_SEED_S) != 0) {
+			System.out.printf("[%s] Using %s.%s of: %s %n", QLearningMovement.class.getName(), QLEARNING_NS, LEARNING_SEED_S, s.getInt(LEARNING_SEED_S));
 			learningRNG = new Random(s.getInt(LEARNING_SEED_S));
 		} else if (s.contains(LEARNING_SEED_S) && s.getInt(LEARNING_SEED_S) == 0) {
+			System.out.printf("[%s] Using a random learning RNG seed.", QLearningMovement.class.getName());
 			learningRNG = new Random();
 		} else {
 			// Inherit the seed from MovementModel
+			System.out.printf("[%s] Using a random learning RNG seed inherited from MovementModel.", QLearningMovement.class.getName());
 			Settings movementSettings = new Settings(MOVEMENT_MODEL_NS);
 			if (movementSettings.contains(RNG_SEED) && movementSettings.getInt(RNG_SEED) != 0) {
 				learningRNG = new Random(movementSettings.getInt(RNG_SEED));

--- a/src/movement/rl/QLearningMovement.java
+++ b/src/movement/rl/QLearningMovement.java
@@ -141,9 +141,9 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 		this.foundReward = s.getDouble(FOUND_REWARD_S, 10.0);
 
 		// Load the behavior policy & target prefix
-		System.out.println("before loading BP");
+//		System.out.println("before loading BP");
 		String behaviorClassName = s.getSetting(BEHAVIOR_POLICY_S, "movement.rl.behavior.EpsilonGreedyBehavior");
-		System.out.println("is it loading this");
+//		System.out.println("is it loading this");
 		this.behaviorPolicy = (BehaviorPolicy) s.createIntializedObject(behaviorClassName);
 		this.targetPrefix = s.getSetting(TARGET_PREFIX_S, "T");
 		this.agentSpeed = s.getDouble(SPEED_S, 1.0);

--- a/src/movement/rl/QLearningMovement.java
+++ b/src/movement/rl/QLearningMovement.java
@@ -239,7 +239,13 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 		this.currentState = proto.currentState;
 		this.currentTrajectorySteps = proto.currentTrajectorySteps;
 		this.direction = proto.direction;
-		this.currentPosition = proto.currentPosition;
+
+		if (proto.currentPosition != null) {
+			this.currentPosition = new Coord(proto.currentPosition.getX(), proto.currentPosition.getY());
+		} else {
+			this.currentPosition = null;
+		}
+
 	}
 
 	/**
@@ -680,6 +686,7 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 		this.currentTrajectorySteps = epd.currentTrajectorySteps;
 		this.direction = epd.direction;
 		this.currentPosition = epd.currentPosition;
+		System.out.println("Loading EPD.currentPosition: " + epd.currentPosition);
 
 		/* Loading Q-Table */
 		qTable.clear();

--- a/src/movement/rl/QLearningMovement.java
+++ b/src/movement/rl/QLearningMovement.java
@@ -116,7 +116,7 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 	/**
 	 * Stores the previous Coordinate of the agent
 	 */
-	private Coord lastWaypoint;
+	private Coord currentPosition;
 	/**
 	 * A radian value representing the direction of movement, used for reward calculation. Range: [0, 2*PI].
 	 */
@@ -160,7 +160,7 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 
 		// Initialize direction randomly
 		this.direction = rng.nextDouble() * 2 * Math.PI;
-		this.lastWaypoint = null; // will be initialized on first getPath()
+		this.currentPosition = null; // will be initialized on first getPath()
 
 		// Re/Initializes episodic persistence
 		EpisodicPersistenceData epd = EpisodicPersistenceManager.loadIfExists();
@@ -222,7 +222,7 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 		this.currentState = proto.currentState;
 		this.currentTrajectorySteps = proto.currentTrajectorySteps;
 		this.direction = proto.direction;
-		this.lastWaypoint = proto.lastWaypoint;
+		this.currentPosition = proto.currentPosition;
 	}
 
 	protected int selectAction(int state, Set<Integer> availableActions) {
@@ -368,14 +368,14 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 
 		/* Generate path for this action. */
 		Path p = new Path(agentSpeed);
-		p.addWaypoint(lastWaypoint);
+		p.addWaypoint(currentPosition);
 
-		double nextX = lastWaypoint.getX() + agentSpeed * Math.cos(direction);
-		double nextY = lastWaypoint.getY() + agentSpeed * Math.sin(direction);
+		double nextX = currentPosition.getX() + agentSpeed * Math.cos(direction);
+		double nextY = currentPosition.getY() + agentSpeed * Math.sin(direction);
 
 		// If the straight step would exit the world bounds, bounce off the wall instead.
 		if (nextX >= getMaxX() || nextY >= getMaxY() || nextX <= 0 || nextY <= 0) {
-			double[] bounced = bounce(lastWaypoint.getX(), lastWaypoint.getY(), nextX, nextY);
+			double[] bounced = bounce(currentPosition.getX(), currentPosition.getY(), nextX, nextY);
 			double bounceX = bounced[0];
 			double bounceY = bounced[1];
 			direction = bounced[2]; // reflected direction
@@ -396,7 +396,7 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 
 		Coord nextWaypoint = new Coord(nextX, nextY);
 		p.addWaypoint(nextWaypoint);
-		lastWaypoint = nextWaypoint;
+		currentPosition = nextWaypoint;
 
 		return p;
 	}
@@ -484,7 +484,7 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 	public Coord getInitialLocation() {
 		assert rng != null : "MovementModel not initialized!";
 		Coord c = new Coord(rng.nextDouble() * getMaxX(), rng.nextDouble() * getMaxY());
-		this.lastWaypoint = c;
+		this.currentPosition = c;
 		return c;
 	}
 

--- a/src/movement/rl/QLearningMovement.java
+++ b/src/movement/rl/QLearningMovement.java
@@ -437,6 +437,8 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 		p.addWaypoint(nextWaypoint);
 		currentPosition = nextWaypoint;
 
+//		if (SimClock.getTime() % 1000 == 1) System.out.println("CURRENT POSITION: " + currentPosition);
+
 		return p;
 	}
 
@@ -521,10 +523,14 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 	 */
 	@Override
 	public Coord getInitialLocation() {
-		assert rng != null : "MovementModel not initialized!";
-		Coord c = new Coord(rng.nextDouble() * getMaxX(), rng.nextDouble() * getMaxY());
-		this.currentPosition = c;
-		return c;
+		if (currentPosition != null) {
+			return currentPosition;
+		} else {
+			assert rng != null : "MovementModel not initialized!";
+			Coord c = new Coord(rng.nextDouble() * getMaxX(), rng.nextDouble() * getMaxY());
+			this.currentPosition = c;
+			return c;
+		}
 	}
 
 	@Override
@@ -626,6 +632,7 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 		epd.currentState = this.currentState;
 		epd.currentTrajectorySteps = this.currentTrajectorySteps;
 		epd.direction = this.direction;
+		epd.currentPosition = this.currentPosition;
 
 		/* Saving Q-Table */
 		epd.qTable = new HashMap<>();
@@ -669,6 +676,7 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 		this.currentState = epd.currentState;
 		this.currentTrajectorySteps = epd.currentTrajectorySteps;
 		this.direction = epd.direction;
+		this.currentPosition = epd.currentPosition;
 
 		/* Loading Q-Table */
 		qTable.clear();

--- a/src/movement/rl/behavior/BehaviorPolicy.java
+++ b/src/movement/rl/behavior/BehaviorPolicy.java
@@ -5,6 +5,7 @@ import movement.rl.persistence.EpisodicPersistable;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 
 /**
@@ -45,4 +46,9 @@ public interface BehaviorPolicy extends EpisodicPersistable, Serializable, Clone
      * Get policy name for logging/debugging
      */
     String getName();
+
+	/**
+	 * Sets the Random instance for the current behavioral policy for learning (exploration) decisions.
+	 * */
+	void setRandom(Random random);
 }

--- a/src/movement/rl/behavior/EpsilonGreedyBehavior.java
+++ b/src/movement/rl/behavior/EpsilonGreedyBehavior.java
@@ -140,6 +140,11 @@ public class EpsilonGreedyBehavior implements BehaviorPolicy {
 	}
 
 	@Override
+	public void setRandom(Random random) {
+		this.random = random;
+	}
+
+	@Override
 	public void saveTo(EpisodicPersistenceData epd) {
 		epd.epsilon = this.epsilon;
 		System.out.println("[EpsilonGreedyBehavior] Saved epsilon of: " + epd.epsilon);

--- a/src/movement/rl/behavior/ThompsonSamplingBehavior.java
+++ b/src/movement/rl/behavior/ThompsonSamplingBehavior.java
@@ -156,6 +156,11 @@ public class ThompsonSamplingBehavior implements BehaviorPolicy {
 	}
 
 	@Override
+	public void setRandom(Random random) {
+		this.random = random;
+	}
+
+	@Override
 	public void saveTo(EpisodicPersistenceData epd) {
 		// Save Thompson Sampling state variables to persistence data
 		if (epd.tsProperties == null) {

--- a/src/movement/rl/behavior/UCBBehavior.java
+++ b/src/movement/rl/behavior/UCBBehavior.java
@@ -157,6 +157,11 @@ public class UCBBehavior implements BehaviorPolicy {
 	}
 
 	@Override
+	public void setRandom(Random random) {
+		this.random = random;
+	}
+
+	@Override
 	public void saveTo(EpisodicPersistenceData epd) {
 		/* Save exploration constant */
 		epd.ucbExplorationConstant = this.explorationConstant;

--- a/src/movement/rl/persistence/EpisodicPersistenceData.java
+++ b/src/movement/rl/persistence/EpisodicPersistenceData.java
@@ -1,5 +1,7 @@
 package movement.rl.persistence;
 
+import core.Coord;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -28,6 +30,7 @@ public class EpisodicPersistenceData {
 	public int currentState;
 	public int currentTrajectorySteps;
 	public double direction;
+	public Coord currentPosition;
 
 	// [ TrajectoryFrequencyReporting ]
 	public Map<String, Integer> trajectoryFrequencies = new HashMap<>();


### PR DESCRIPTION
## Main Changes

This branch resolves #53 which now [QLearningMovement.java](https://github.com/vianneynara/onesim-rl/blob/feat/53-add-optional-unchanging-node-placements-and-agent-coordinate-saving/src/movement/rl/QLearningMovement.java)have more options whether to use the [MovementModel.java](https://github.com/vianneynara/onesim-rl/blob/feat/53-add-optional-unchanging-node-placements-and-agent-coordinate-saving/src/movement/MovementModel.java) or a set `QLearningMovement.learningSeed` (int/long) on the Behavioral Policy.

- Now each next episodes will initialize the agent's position based on the previous episode last position.
- Added `currentPosition` in persistence classes.
- Renamed `lastWaypoint` to `currentPosition` to avoid confusion.
- Added and implemented setRandom to change the RNG to be used in [BehaviorPolicy.java](https://github.com/vianneynara/onesim-rl/blob/feat/53-add-optional-unchanging-node-placements-and-agent-coordinate-saving/src/movement/rl/behavior/BehaviorPolicy.java) implementors.

## Other Changes

Added copy constructor on Coord.