### PR TITLE
Fix X axis drawing on logarithmic trajectory grapher

### DIFF
--- a/pyplotters/persistence_plotter.py
+++ b/pyplotters/persistence_plotter.py
@@ -116,9 +116,6 @@ def retrieve_trajectoryFrequencies(_json_data):
 
     # Calculate PDF (Probability Mass Function) using Kernel Density Estimation
     trajectory_values = traj_freq_df["trajectory"].astype(int).values
-    # Create weights based on frequency for KDE
-    kde = gaussian_kde(trajectory_values, weights=traj_freq_df["frequency"].values, bw_method='scott')
-    traj_freq_df["pdf"] = kde(trajectory_values)
 
     return traj_freq_df
 
@@ -134,9 +131,8 @@ def plot_trajectoryDistribution(_df: pd.DataFrame, file_path: str, logarithmic_x
     if not logarithmic_x:
         # Plot both probability and PDF
         sns.lineplot(data=_df, x="trajectory", y="probability", label="Probability (PMF)", linewidth=2)
-        sns.lineplot(data=_df, x="trajectory", y="pdf", label="Probability Density (KDE)", linewidth=2, linestyle="--")
 
-        plt.title("Trajectory Distribution: PMF vs PDF")
+        plt.title("Trajectory Distribution (Probability Mass Function)")
         plt.xlabel("Trajectory Length")
         plt.ylabel("Probability / Density")
         plt.gca().set_yticks(np.arange(0, 1.1, 0.1))
@@ -147,9 +143,8 @@ def plot_trajectoryDistribution(_df: pd.DataFrame, file_path: str, logarithmic_x
     else:
         # Logarithmic X-axis
         sns.lineplot(data=_df, x="trajectory", y="probability", label="Probability (PMF)", linewidth=2)
-        sns.lineplot(data=_df, x="trajectory", y="pdf", label="Probability Density (KDE)", linewidth=2, linestyle="--")
 
-        plt.title("Trajectory Distribution: PMF vs PDF (Logarithmic Scale)")
+        plt.title("Trajectory Distribution (Probability Mass Function)")
         plt.xlabel("Trajectory Length (log scale)")
         plt.ylabel("Probability / Density")
 
@@ -164,14 +159,6 @@ def plot_trajectoryDistribution(_df: pd.DataFrame, file_path: str, logarithmic_x
         # Defaults x_max to the max amount of the current data
         x_max = max_trajectory * np.ceil(np.log10(max_trajectory))
 
-        # if max_trajectory < 10 ** 2:
-        #     x_max = 10 ** 2  # At least show up to 10^2
-        # elif max_trajectory < 10 ** 3:
-        #     x_max = 10 ** 3  # If data reaches 10^2, show up to 10^3
-        # else:
-        #     x_max = 10 ** 4  # If data exceeds 10^3, show up to 10^4
-
-        ax.set_xlim(x_min, x_max)
         ax.xaxis.set_major_locator(LogLocator(base=10.0, numticks=10))
         ax.xaxis.set_major_formatter(LogFormatterMathtext(base=10.0))
 

--- a/pyplotters/persistence_plotter.py
+++ b/pyplotters/persistence_plotter.py
@@ -17,7 +17,7 @@ import matplotlib.pyplot as plt
 
 from typing import List, Tuple, Union
 from scipy.stats import gaussian_kde
-from matplotlib.ticker import LogLocator, LogFormatter, LogFormatterMathtext, FormatStrFormatter
+from matplotlib.ticker import LogLocator, LogFormatter, LogFormatterMathtext, FormatStrFormatter, MultipleLocator
 
 BASE_REPORTS_DIR = "reports\\skripsi"
 PLOT_RESULTS_DIR = "pyplotters\\plots"
@@ -127,6 +127,25 @@ def plot_trajectoryDistribution(_df: pd.DataFrame, file_path: str, logarithmic_x
     - Orange line: Smoothed PDF (KDE)
     """
     plt.figure(figsize=(12, 6))
+    xmax_plot = 500
+
+    # Ensure numeric dtypes (JSON keys often arrive as strings)
+    _df = _df.copy()
+    _df["trajectory"] = _df["trajectory"].astype(int)
+    _df["probability"] = _df["probability"].astype(float)
+
+    # Summary statistics to display in legend
+    max_len = None
+    mean_len = None
+    max_p = None
+    mode_len = None
+    if len(_df) > 0 and float(_df["probability"].sum()) > 0:
+        max_len = int(_df["trajectory"].max())
+        # Expected trajectory length under PMF
+        mean_len = float((_df["trajectory"] * _df["probability"]).sum())
+        # Most probable trajectory length (mode); in ties pick the smallest length
+        max_p = _df["probability"].max()
+        mode_len = int(_df.loc[_df["probability"] == max_p, "trajectory"].min())
 
     if not logarithmic_x:
         # Plot both probability and PDF
@@ -135,9 +154,29 @@ def plot_trajectoryDistribution(_df: pd.DataFrame, file_path: str, logarithmic_x
         plt.title("Trajectory Distribution (Probability Mass Function)")
         plt.xlabel("Trajectory Length")
         plt.ylabel("Probability / Density")
+
+        ax = plt.gca()
+        ax.set_xlim(1, xmax_plot)
+
+        # Major tick every 200; minor tick every 50 (optional)
+        ax.xaxis.set_major_locator(MultipleLocator(50))
+        ax.xaxis.set_minor_locator(MultipleLocator(50))
+
         plt.gca().set_yticks(np.arange(0, 1.1, 0.1))
         plt.margins(x=0)
-        plt.legend()
+
+        # Add summary stats into legend without adding visual lines to the plot.
+        # To keep the column alignment, render legend text using a monospace font.
+        handles, labels = ax.get_legend_handles_labels()
+        if max_len is not None:
+            from matplotlib.lines import Line2D
+            handles.extend([
+                Line2D([], [], linestyle='none', color='none', label=f"      Max trajectory : {max_len}"),
+                Line2D([], [], linestyle='none', color='none', label=f"         Highest PMF : {max_p:.2f}"),
+                Line2D([], [], linestyle='none', color='none', label=f"   Mean length (PMF) : {mean_len:.2f}"),
+                Line2D([], [], linestyle='none', color='none', label=f"Most probable (mode) : {mode_len}"),
+            ])
+        ax.legend(handles=handles, loc="best", prop={'family': 'monospace'})
         plt.savefig(file_path, bbox_inches='tight')
         plt.close()
     else:
@@ -152,21 +191,26 @@ def plot_trajectoryDistribution(_df: pd.DataFrame, file_path: str, logarithmic_x
         ax = plt.gca()
         ax.set_xscale('log')
 
-        # Determine X-axis limits based on max trajectory value
-        max_trajectory = float(_df["trajectory"].max())
-        x_min = 10 ** 0  # Always start from 10^0
-
-        # Defaults x_max to the max amount of the current data
-        x_max = max_trajectory * np.ceil(np.log10(max_trajectory))
-
-        ax.xaxis.set_major_locator(LogLocator(base=10.0, numticks=10))
-        ax.xaxis.set_major_formatter(LogFormatterMathtext(base=10.0))
+        # Set X-axis ticks from 10^0 to 10^3
+        # xmax_plot = _df["trajectory"].max()
+        ax.set_xlim(1, xmax_plot)
+        ax.set_xticks([1, 10, 100, 1000])
 
         # Y-axis ticks at 0.1 intervals
         ax.set_yticks(np.arange(0, 1.1, 0.1))
 
         plt.margins(x=0)
-        plt.legend()
+
+        handles, labels = ax.get_legend_handles_labels()
+        if max_len is not None:
+            from matplotlib.lines import Line2D
+            handles.extend([
+                Line2D([], [], linestyle='none', color='none', label=f"      Max trajectory : {max_len}"),
+                Line2D([], [], linestyle='none', color='none', label=f"         Highest PMF : {max_p:.2f}"),
+                Line2D([], [], linestyle='none', color='none', label=f"   Mean length (PMF) : {mean_len:.2f}"),
+                Line2D([], [], linestyle='none', color='none', label=f"Most probable (mode) : {mode_len}"),
+            ])
+        ax.legend(handles=handles, loc="best", prop={'family': 'monospace'})
         plt.savefig(file_path, bbox_inches='tight')
         plt.close()
 
@@ -216,7 +260,7 @@ def process_reports(_run_id_dir):
     common_df.to_csv(common_df_path, index=False, sep=";", header=True)
 
     # currentEpisodeReward
-    pp_currentEpisodeReward = os.path.join(PLOT_RESULTS_DIR, _run_id_dir.split("\\")[-1], f"currentEpisodeReward.png")
+    pp_currentEpisodeReward = os.path.join(PLOT_RESULTS_DIR, _run_id_dir.split("\\")[-1], f"Current Episode Reward.png")
     plot_by_episode(
         common_df,
         "currentEpisodeReward",
@@ -227,7 +271,7 @@ def process_reports(_run_id_dir):
     )
 
     # currentEpisodeReward
-    pp_currentCumulativeReward = os.path.join(PLOT_RESULTS_DIR, _run_id_dir.split("\\")[-1], f"currentCumulativeReward.png")
+    pp_currentCumulativeReward = os.path.join(PLOT_RESULTS_DIR, _run_id_dir.split("\\")[-1], f"Current Cumulative Reward.png")
     plot_by_episode(
         common_df,
         "currentCumulativeReward",
@@ -238,7 +282,7 @@ def process_reports(_run_id_dir):
     )
 
     # currentTrueDetections
-    pp_currentTrueDetections = os.path.join(PLOT_RESULTS_DIR, _run_id_dir.split("\\")[-1], f"currentTrueDetections.png")
+    pp_currentTrueDetections = os.path.join(PLOT_RESULTS_DIR, _run_id_dir.split("\\")[-1], f"Current True Detections.png")
     plot_by_episode(
         common_df,
         "currentTrueDetections",
@@ -249,7 +293,7 @@ def process_reports(_run_id_dir):
     )
 
     # currentUniqueDetections
-    pp_currentUniqueDetections = os.path.join(PLOT_RESULTS_DIR, _run_id_dir.split("\\")[-1], f"currentUniqueDetections.png")
+    pp_currentUniqueDetections = os.path.join(PLOT_RESULTS_DIR, _run_id_dir.split("\\")[-1], f"Current Unique Detections.png")
     plot_by_episode(
         common_df,
         "currentUniqueDetections",
@@ -262,11 +306,11 @@ def process_reports(_run_id_dir):
     # trajectory distribution
     plot_trajectoryDistribution(
         traj_freq_df,
-        os.path.join(PLOT_RESULTS_DIR, _run_id_dir.split("\\")[-1], f"trajectoryDistribution.png")
+        os.path.join(PLOT_RESULTS_DIR, _run_id_dir.split("\\")[-1], f"Trajectory Distribution.png")
     )
     plot_trajectoryDistribution(
         traj_freq_df,
-        os.path.join(PLOT_RESULTS_DIR, _run_id_dir.split("\\")[-1], f"trajectoryDistributionLog.png"),
+        os.path.join(PLOT_RESULTS_DIR, _run_id_dir.split("\\")[-1], f"Trajectory Distribution (log scale).png"),
         logarithmic_x=True
     )
 

--- a/pyplotters/persistence_plotter.py
+++ b/pyplotters/persistence_plotter.py
@@ -76,13 +76,28 @@ def sequence_of_currentEpisodeReward(json_data) -> list[int]:
     return episodic_rewards
 
 
-def plot_by_episode(_df: pd.DataFrame, _key: str, _title: str, _xlabel: str, _ylabel: str, file_path: str):
+def plot_by_episode(_df: pd.DataFrame, _key: str, _title: str, _xlabel: str, _ylabel: str, file_path: str, _yalias: str = None, _discrete: bool = False):
     plt.figure(figsize=(10, 6))
+
+    if not _yalias:
+        _yalias = _ylabel
 
     max_episodes = _df["episodeNumber"].max()
     min_episodes = _df["episodeNumber"].min()
 
     sns.lineplot(data=_df, x="episodeNumber", y=_key)
+
+    # Summary statistics for the selected Y series
+    y = pd.to_numeric(_df[_key], errors="coerce")
+    y = y.dropna()
+    y_max = y_min = y_mean = y_mode = None
+    if len(y) > 0:
+        y_max = float(y.max())
+        y_min = float(y.min())
+        y_mean = float(y.mean())
+        # Pandas mode can return multiple values; pick the first (smallest)
+        modes = y.mode()
+        y_mode = float(modes.iloc[0]) if len(modes) > 0 else None
 
     if max_episodes <= 20:
         ticks = np.arange(min_episodes, max_episodes + 1, 1)
@@ -94,12 +109,41 @@ def plot_by_episode(_df: pd.DataFrame, _key: str, _title: str, _xlabel: str, _yl
     plt.xticks(ticks)
 
     # Labels & title
-    plt.title(_title)
+    plt.title(_title, fontweight='bold')
     plt.xlabel(_xlabel)
     plt.ylabel(_ylabel)
 
     plt.margins(x=0)
     plt.xlim(left=min_episodes)
+
+    # Add summary stats into legend without adding visual lines to the plot.
+    ax = plt.gca()
+    handles, labels = ax.get_legend_handles_labels()
+    if y_max is not None:
+        from matplotlib.lines import Line2D
+
+        # Use monospace to keep alignment stable
+        if not _discrete:
+            stat_lines = [
+                f"{'Highest ' + _yalias:<20}: {y_max:>10.4f}",
+                f"{'Lowest ' + _yalias:<20}: {y_min:>10.4f}",
+                f"{'Mean ' + _yalias:<20}: {y_mean:>10.4f}",
+            ]
+        else:
+            y_max = int(y_max)
+            y_min = int(y_min)
+            stat_lines = [
+                f"{'Highest ' + _yalias:<20}: {y_max:>10d}",
+                f"{'Lowest ' + _yalias:<20}: {y_min:>10d}",
+                f"{'Mean ' + _yalias:<20}: {y_mean:>10.2f}",
+            ]
+        # if y_mode is not None:
+        #     stat_lines.append(f"{'Mode ' + _yalias:<24}: {y_mode:>12.4f}")
+
+        handles.extend([Line2D([], [], linestyle='none', color='none', label=s) for s in stat_lines])
+
+    if handles:
+        ax.legend(handles=handles, loc="best", prop={'family': 'monospace'})
     plt.savefig(file_path, bbox_inches='tight')
     plt.close()
 
@@ -159,7 +203,7 @@ def plot_trajectoryDistribution(_df: pd.DataFrame, file_path: str, logarithmic_x
         ax.set_xlim(1, xmax_plot)
 
         # Major tick every 200; minor tick every 50 (optional)
-        ax.xaxis.set_major_locator(MultipleLocator(50))
+        ax.xaxis.set_major_locator(MultipleLocator(200))
         ax.xaxis.set_minor_locator(MultipleLocator(50))
 
         plt.gca().set_yticks(np.arange(0, 1.1, 0.1))
@@ -170,12 +214,13 @@ def plot_trajectoryDistribution(_df: pd.DataFrame, file_path: str, logarithmic_x
         handles, labels = ax.get_legend_handles_labels()
         if max_len is not None:
             from matplotlib.lines import Line2D
-            handles.extend([
-                Line2D([], [], linestyle='none', color='none', label=f"      Max trajectory : {max_len}"),
-                Line2D([], [], linestyle='none', color='none', label=f"         Highest PMF : {max_p:.2f}"),
-                Line2D([], [], linestyle='none', color='none', label=f"   Mean length (PMF) : {mean_len:.2f}"),
-                Line2D([], [], linestyle='none', color='none', label=f"Most probable (mode) : {mode_len}"),
-            ])
+            stat_lines = [
+                f"{'Max trajectory':<20}: {max_len:>6d}",
+                f"{'Highest PMF':<20}: {max_p:>10.3f}",
+                f"{'Mean length (PMF)':<20}: {mean_len:>10.2f}",
+                f"{'Most probable (mode)':<20}: {mode_len:>6d}",
+            ]
+            handles.extend([Line2D([], [], linestyle='none', color='none', label=s) for s in stat_lines])
         ax.legend(handles=handles, loc="best", prop={'family': 'monospace'})
         plt.savefig(file_path, bbox_inches='tight')
         plt.close()
@@ -204,12 +249,13 @@ def plot_trajectoryDistribution(_df: pd.DataFrame, file_path: str, logarithmic_x
         handles, labels = ax.get_legend_handles_labels()
         if max_len is not None:
             from matplotlib.lines import Line2D
-            handles.extend([
-                Line2D([], [], linestyle='none', color='none', label=f"      Max trajectory : {max_len}"),
-                Line2D([], [], linestyle='none', color='none', label=f"         Highest PMF : {max_p:.2f}"),
-                Line2D([], [], linestyle='none', color='none', label=f"   Mean length (PMF) : {mean_len:.2f}"),
-                Line2D([], [], linestyle='none', color='none', label=f"Most probable (mode) : {mode_len}"),
-            ])
+            stat_lines = [
+                f"{'Max trajectory':<20}: {max_len:>10d}",
+                f"{'Highest PMF':<20}: {max_p:>10.6f}",
+                f"{'Mean length (PMF)':<20}: {mean_len:>10.2f}",
+                f"{'Most probable (mode)':<20}: {mode_len:>10d}",
+            ]
+            handles.extend([Line2D([], [], linestyle='none', color='none', label=s) for s in stat_lines])
         ax.legend(handles=handles, loc="best", prop={'family': 'monospace'})
         plt.savefig(file_path, bbox_inches='tight')
         plt.close()
@@ -267,7 +313,8 @@ def process_reports(_run_id_dir):
         "Current Episode Reward",
         "Episode",
         "Reward",
-        pp_currentEpisodeReward
+        pp_currentEpisodeReward,
+        _yalias="reward"
     )
 
     # currentEpisodeReward
@@ -278,7 +325,8 @@ def process_reports(_run_id_dir):
         "Current Cumulative Reward",
         "Episode",
         "Reward",
-        pp_currentCumulativeReward
+        pp_currentCumulativeReward,
+        _yalias="cumu. reward"
     )
 
     # currentTrueDetections
@@ -289,7 +337,9 @@ def process_reports(_run_id_dir):
         "Current True Detections",
         "Episode",
         "Detection",
-        pp_currentTrueDetections
+        pp_currentTrueDetections,
+        _yalias="detection",
+        _discrete=True
     )
 
     # currentUniqueDetections
@@ -300,7 +350,9 @@ def process_reports(_run_id_dir):
         "Current Unique Detections",
         "Episode",
         "Detection",
-        pp_currentUniqueDetections
+        pp_currentUniqueDetections,
+        _yalias="uniq. detection",
+        _discrete=True
     )
 
     # trajectory distribution

--- a/pyplotters/persistence_plotter.py
+++ b/pyplotters/persistence_plotter.py
@@ -325,11 +325,11 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "-ao", "--all_of", type=str, help="The parent report source directory. (e.g. \"ql\")"
+        "-aof", "--all_of", type=str, help="The parent report source directory. (e.g. \"ql\")"
     )
 
     parser.add_argument(
-        "-ri", "--run_id", type=str, help="The parent report source directory. (e.g. \"ql\")"
+        "-rid", "--run_id", type=str, help="The parent report source directory. (e.g. \"ql\")"
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
Fixed #80 where the X axis for logarithmic ticks are written wrongly. Now it will properly show $10^0,10^1,10^2,10^3$ logarithmic ticks. I have also modified the non-logarithmic flow to use steps of 50 values for the linear X axis.

Also added `_yalias: str` and `_discrete: str` for plot_by_episode(). This is useful for detection counting graphs.