### PR TITLE
Investigate Thompson Sampling and addition to BehaviorPolicy interface

### DIFF
--- a/settings/skripsi/randomsearch-qlearn.cfg
+++ b/settings/skripsi/randomsearch-qlearn.cfg
@@ -124,6 +124,7 @@ BehaviorPolicy.EpsilonGreedy.minEpsilon = 0.1
 BehaviorPolicy.UCB.explorationConstant = 2
 
 [ TSBehavior settings ]
+BehaviorPolicy.TS.alpha = 0.01
 BehaviorPolicy.TS.initialVariance = 1.0
 
 [ Episode persistence ]

--- a/src/movement/rl/QLearningMovement.java
+++ b/src/movement/rl/QLearningMovement.java
@@ -292,11 +292,11 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 		double maxNextQ = getMaxQ(nextState, availableNextActions);
 
 		// Q-Learning update: Q(s,a) = Q(s,a) + α[r + λ max Q(s',a') - Q(s,a)]
-		double newQ = currentQ + alpha * (reward + lambda * maxNextQ - currentQ);
-		setQ(state, action, newQ);
+		double updatedQ = currentQ + alpha * (reward + lambda * maxNextQ - currentQ);
+		setQ(state, action, updatedQ);
 
 		// Update the behavior policy
-		behaviorPolicy.update(state, action, reward);
+		behaviorPolicy.update(state, action, reward, currentQ, maxNextQ, updatedQ);
 	}
 
 	/**

--- a/src/movement/rl/behavior/BehaviorPolicy.java
+++ b/src/movement/rl/behavior/BehaviorPolicy.java
@@ -35,7 +35,7 @@ public interface BehaviorPolicy extends EpisodicPersistable, Serializable, Clone
      * @param actionIndex Action that was taken
      * @param reward Reward received
      */
-    void update(int stateId, Integer actionIndex, double reward);
+    void update(int stateId, int actionIndex, double reward, double prevQ, double prevMaxNextQ, double updatedQ);
     
     /**
      * Create a copy of this policy

--- a/src/movement/rl/behavior/EpsilonGreedyBehavior.java
+++ b/src/movement/rl/behavior/EpsilonGreedyBehavior.java
@@ -78,7 +78,7 @@ public class EpsilonGreedyBehavior implements BehaviorPolicy {
 	 * Parameters are unused for Epsilon Greedy.
 	 */
 	@Override
-	public void update(int stateId, Integer actionIndex, double reward) {
+	public void update(int stateId, int actionIndex, double reward, double prevQ, double prevMaxNextQ, double updatedQ) {
 		/* ε_t+1 = max(ε, ε • decay rate) */
 		epsilon = Math.max(minEpsilon, epsilon * epsilonDecay);
 	}

--- a/src/movement/rl/behavior/ThompsonSamplingBehavior.java
+++ b/src/movement/rl/behavior/ThompsonSamplingBehavior.java
@@ -19,12 +19,26 @@ import java.util.*;
 public class ThompsonSamplingBehavior implements BehaviorPolicy {
 
 	private Random random;
+	private final double alpha;
 	private final double initialVariance;
 	private final Map<StateActionPair, TSProperty> tsProperties;
 
 	public static final String BEHAVIOR_NS = "BehaviorPolicy.TS";
-
-	public static final double DEFAULT_INITIAL_VARIANCE = 1.0;
+	/**
+	 * The "learning rate" for updating posterior mean toward the new reward (new Q).
+	 * Controlling how quick the mean tracks the Q-value from the Q-Table.
+	 * This is an adaptation for the RL environment, where Q value changes continuously during learning.
+	 * <p>
+	 * Note: Match the learning rate of Q-Learning or Monte Carlo being implemented.
+	 * </p>
+	 * */
+	public static final String ALPHA_S = "alpha";
+	/**
+	 * The initial uncertainty of the posterior distribution for each state-action.
+	 * Higher value means agent is more uncertain about all actions (more exploration).
+	 * As visit count increases, variance decays monotonically via Bayesian decay: σ²(n) = σ²₀ / (1 + n).
+	 * */
+	public static final String INITIAL_VARIANCE_S = "initialVariance";
 
 	/**
 	 * Constructor called reflectively by Settings. The {@code _settings} param is unused
@@ -41,12 +55,14 @@ public class ThompsonSamplingBehavior implements BehaviorPolicy {
 			this.random = new Random();
 		}
 
-		this.initialVariance = behaviorSettings.getDouble("initialVariance", DEFAULT_INITIAL_VARIANCE);
+		this.alpha = behaviorSettings.getDouble(ALPHA_S, 0.01);
+		this.initialVariance = behaviorSettings.getDouble(INITIAL_VARIANCE_S, 1.0);
 		this.tsProperties = new HashMap<>();
 	}
 
 	public ThompsonSamplingBehavior(ThompsonSamplingBehavior proto) {
 		this.random = proto.random;
+		this.alpha = proto.alpha;
 		this.initialVariance = proto.initialVariance;
 		this.tsProperties = new HashMap<>(proto.tsProperties);
 	}
@@ -114,7 +130,7 @@ public class ThompsonSamplingBehavior implements BehaviorPolicy {
 		TSProperty prop = tsProperties.getOrDefault(pair, new TSProperty(0, initialVariance, 0));
 
 		double currMean = prop.getMu();
-		double currVariance = prop.getSigma2();
+//		double currVariance = prop.getSigma2();
 		int currVisitCount = prop.getVisitCount();
 
 		// Increment visit count
@@ -122,7 +138,7 @@ public class ThompsonSamplingBehavior implements BehaviorPolicy {
 		prop.incrementVisitCount();
 
 		// Update mean using incremental average: μ_new = μ_old + (r - μ_old) / n
-		double updatedMean = currMean + (reward - currMean) / newVisitCount;
+		double updatedMean = currMean + alpha * (updatedQ - currMean);
 
 		// Update variance using incremental formula for running variance
 		// σ²_new = σ²_old + (r - μ_old)(r - μ_new) / n
@@ -132,7 +148,9 @@ public class ThompsonSamplingBehavior implements BehaviorPolicy {
 			// I don't know which variance is proper for initializing the Thompson Sampling yet
 			updatedVariance = initialVariance;
 		} else {
-			updatedVariance = currVariance + (reward - currMean) * (reward - updatedMean) / newVisitCount;
+//			updatedVariance = currVariance + (reward - currMean) * (reward - updatedMean) / newVisitCount;
+			// Variance: monotone Bayesian decay
+			updatedVariance = initialVariance / (1.0 + newVisitCount);
 		}
 
 		// This ensures variance to not exceed 0.000001, avoiding zero

--- a/src/movement/rl/behavior/ThompsonSamplingBehavior.java
+++ b/src/movement/rl/behavior/ThompsonSamplingBehavior.java
@@ -109,7 +109,7 @@ public class ThompsonSamplingBehavior implements BehaviorPolicy {
 	 * @param reward      Observed reward from the action
 	 */
 	@Override
-	public void update(int stateId, Integer actionIndex, double reward) {
+	public void update(int stateId, int actionIndex, double reward, double prevQ, double prevMaxNextQ, double updatedQ) {
 		StateActionPair pair = StateActionPair.of(stateId, actionIndex);
 		TSProperty prop = tsProperties.getOrDefault(pair, new TSProperty(0, initialVariance, 0));
 

--- a/src/movement/rl/behavior/UCBBehavior.java
+++ b/src/movement/rl/behavior/UCBBehavior.java
@@ -136,7 +136,7 @@ public class UCBBehavior implements BehaviorPolicy {
 	 * @param actionIndex Action that was taken
 	 */
 	@Override
-	public void update(int stateId, Integer actionIndex, double reward) {
+	public void update(int stateId, int actionIndex, double reward, double prevQ, double prevMaxNextQ, double updatedQ) {
 		StateActionPair pair = StateActionPair.of(stateId, actionIndex);
 
 		/* Increment N(s,a) - state-action frequency by 1 */


### PR DESCRIPTION
This pull request updates the reinforcement learning (RL) behavior policies to improve the integration between the Q-Learning algorithm and the behavior policies, with a particular focus on the Thompson Sampling (TS) policy. The main changes include enhancing the `update` method to provide more context from the Q-table, introducing a learning rate parameter (`alpha`) for the TS policy, and adjusting the TS mean and variance update rules for better alignment with RL environments.

**API and Interface Changes:**

* The `BehaviorPolicy.update` method signature now includes additional parameters: previous Q-value, previous max Q-value, and updated Q-value, providing more information from the Q-table to behavior policies. [[1]](diffhunk://#diff-f247d047f4dd8f4e25a157ce3c4d89a7d988156b56882df944b104cc5770084cL38-R38) [[2]](diffhunk://#diff-544ea2b804a54b516d14bc67fd88fa2709f8a23a7ca5bcc5575e834d8121cbc1L295-R299)

**Thompson Sampling Behavior Improvements:**

* Added a new `alpha` parameter to `ThompsonSamplingBehavior`, configurable via settings (`BehaviorPolicy.TS.alpha`), which controls how quickly the posterior mean tracks the Q-value. [[1]](diffhunk://#diff-e7d4674729f27a63b78837be9b3387517610286e9e042ba304eb38ca4baaef12R22-R41) [[2]](diffhunk://#diff-e7d4674729f27a63b78837be9b3387517610286e9e042ba304eb38ca4baaef12L44-R65) [[3]](diffhunk://#diff-3bd4a14bb7d37a5fdc92615fe4be93bfb0191257ce45d009bf895718bb430c65R127)
* Updated the mean update rule in TS to use the new `alpha` parameter and the latest Q-value, making the mean adapt more smoothly to Q-Learning updates.
* Changed the variance update rule in TS to a monotonic Bayesian decay, ensuring the variance decreases predictably with more visits, improving exploration/exploitation balance.

**Other Behavior Policy Updates:**

* Updated the `update` method implementations in `EpsilonGreedyBehavior` and `UCBBehavior` to match the new interface, though only the relevant parameters are used for each policy. [[1]](diffhunk://#diff-c04e46030dec4b6f071bd1f76998eb734e7b1a9ee40cbe60cdff2ac23d3b1739L81-R81) [[2]](diffhunk://#diff-6da16f6705310508b99773dde7ce47ad094ae585d192b8a86ba8846728eb51e8L139-R139)

These changes improve the flexibility and learning dynamics of RL behavior policies, especially for Thompson Sampling, enabling better adaptation and experimentation in RL environments.