### PR TITLE
Development

### DIFF
--- a/pyplotters/bestof_plotter.py
+++ b/pyplotters/bestof_plotter.py
@@ -128,7 +128,7 @@ def build_legend_label(group_value: str, overrides: dict[str, str]) -> str:
     return f'{group_display} {"("+overrides_str+")" if overrides_str else ""}'
 
 
-def best_of_by_group(summary_df: pd.DataFrame, group_key: str, addparams: dict[str, str] | None = None) -> pd.DataFrame:
+def best_of_by_group(summary_df: pd.DataFrame, group_key: str, all_of_dir: str, addparams: dict[str, str] | None = None) -> pd.DataFrame:
     """Return DF with the single best run per group value.
     
     Args:
@@ -140,8 +140,6 @@ def best_of_by_group(summary_df: pd.DataFrame, group_key: str, addparams: dict[s
     """
     if "configuration_directory" not in summary_df.columns:
         _exit_with_warning("summary.csv missing required column 'configuration_directory'.")
-    if "max_cumulative_reward" not in summary_df.columns:
-        _exit_with_warning("summary.csv missing required column 'max_cumulative_reward'.")
 
     if addparams is None:
         addparams = {}
@@ -196,13 +194,34 @@ def best_of_by_group(summary_df: pd.DataFrame, group_key: str, addparams: dict[s
     parsed_df = pd.DataFrame(records)
     merged = summary_df.merge(parsed_df, on="configuration_directory", how="left")
 
+    # Read common_data.csv for each run and extract the last episode's currentCumulativeReward
+    last_episode_rewards = []
+    for _, row in merged.iterrows():
+        run_id = str(row["configuration_directory"])
+        # Construct path to common_data.csv
+        common_path = os.path.join(PLOT_RESULTS_DIR, all_of_dir.split("\\")[-1], run_id, "common_data.csv")
+        
+        if not os.path.exists(common_path):
+            _exit_with_warning(
+                f"Missing {common_path}. Generate it with persistence_plotter.py first."
+            )
+        
+        # Read the CSV and get the last episode's currentCumulativeReward
+        common_df = pd.read_csv(common_path, sep=";")
+        if "currentCumulativeReward" not in common_df.columns:
+            _exit_with_warning(f"{common_path} missing required column 'currentCumulativeReward'.")
+
+        # Make sure common_df SORTED by episodeNumber
+        common_df = common_df.sort_values(by="episodeNumber", ascending=True)
+
+        last_reward = float(common_df["currentCumulativeReward"].iloc[-1])
+        last_episode_rewards.append(last_reward)
+    
     merged = merged.copy()
-    merged["max_cumulative_reward"] = pd.to_numeric(merged["max_cumulative_reward"], errors="coerce")
-    if merged["max_cumulative_reward"].isna().any():
-        _exit_with_warning("summary.csv contains non-numeric max_cumulative_reward values; aborting.")
+    merged["last_episode_cumulative_reward"] = last_episode_rewards
 
     merged = merged.sort_values(
-        by=["group_value", "max_cumulative_reward", "configuration_directory"],
+        by=["group_value", "last_episode_cumulative_reward", "configuration_directory"],
         ascending=[True, False, True],
         kind="mergesort",
     )
@@ -295,7 +314,7 @@ def run_bestof(all_of: str, group_key: str, addparams: dict[str, str] | None = N
         )
 
     summary_df = pd.read_csv(summary_path, sep=";")
-    winners = best_of_by_group(summary_df, group_key, addparams)
+    winners = best_of_by_group(summary_df, group_key, all_of, addparams)
 
     log.info(LINE_LENGTH * "-")
     log.info(f"Best-Of selection by group '{group_key}'")
@@ -303,8 +322,9 @@ def run_bestof(all_of: str, group_key: str, addparams: dict[str, str] | None = N
         gv = str(row["group_value"])
         formal = GROUP_VALUE_TERMS.get(gv, "")
         formal_part = f" ({formal})" if formal else ""
+        last_reward = row['last_episode_cumulative_reward']
         log.info(
-            f"{gv}{formal_part}: {row['configuration_directory']} | max_cumulative_reward={row['max_cumulative_reward']}"
+            f"{gv}{formal_part}: {row['configuration_directory']} | last_episode_cumulative_reward={last_reward:.2f}"
         )
     log.info(LINE_LENGTH * "-")
 

--- a/pyplotters/persistence_plotter.py
+++ b/pyplotters/persistence_plotter.py
@@ -40,6 +40,7 @@ LIST_OF_IGNORED_OVERRIDES = [
 SUMMARY_KEYS = [
     "configuration_directory",
     "max_cumulative_reward",
+    "mean_cumulative_reward",
     "max_cumulative_true_detections",
     "max_trajectory_length",
 ]
@@ -419,6 +420,7 @@ def process_reports(_run_id_dir, _parent_dir: str = None, _title: str = None, _d
     COMMON_IDX = ["episodeNumber", "currentEpisodeReward", "currentCumulativeReward", "previousCumulativeReward",
                   "currentTrueDetections", "currentUniqueDetections", "currentCumulativeTrueDetections",
                   "previousCumulativeTrueDetections"]
+    # ADDITIONAL COLUMN: meanCumulativeReward
     common_df = pd.DataFrame(columns=COMMON_IDX)
 
     # Use the last episodic JSON file to determine the number of trajectories
@@ -441,10 +443,19 @@ def process_reports(_run_id_dir, _parent_dir: str = None, _title: str = None, _d
         # Get highest "trajectoryFrequencies" by grabbing and selecting the highest int-casted
         _run_summary["max_trajectory_length"] = max(_run_summary["max_trajectory_length"], max([int(k) for k in json_data["trajectoryFrequencies"].keys()]))
 
+    # Adds a meanCumulativeReward column with expanded mean from currentCumulativeReward
+    common_df["meanCumulativeReward"] = common_df["currentCumulativeReward"].expanding().mean()
+
+    # Calculate mean cumulative reward after all episodes are processed
+    _run_summary["mean_cumulative_reward"] = common_df["currentCumulativeReward"].mean()
+
     # Output directory: pyplotters/plots[/<parent>]/<run_id>/
     _parent_results_dir = os.path.join(PLOT_RESULTS_DIR, _parent_dir) if _parent_dir else PLOT_RESULTS_DIR
     run_out_dir = os.path.join(_parent_results_dir, run_id)
     os.makedirs(run_out_dir, exist_ok=True)
+
+    # SORT common_df by episodeNumber, this wsa critical bruh.
+    common_df = common_df.sort_values(by=["episodeNumber"], ascending=True)
 
     common_df_path = os.path.join(run_out_dir, "common_data.csv")
     common_df.to_csv(common_df_path, index=False, sep=";", header=True)
@@ -479,6 +490,24 @@ def process_reports(_run_id_dir, _parent_dir: str = None, _title: str = None, _d
         pp_currentCumulativeReward,
         _subtitle="Current Cumulative Reward",
         _yalias="Cumu. Reward",
+        _description=_description,
+        # _ema_line=True,
+        # _ma_line=True
+    )
+
+    # Mean Cumulative Reward (cumulative mean across episodes)
+    common_df_with_mean = common_df.copy()
+    common_df_with_mean["meanCumulativeReward"] = common_df_with_mean["currentCumulativeReward"].expanding().mean()
+    pp_meanCumulativeReward = os.path.join(run_out_dir, "Mean Cumulative Reward.png")
+    plot_by_episode(
+        common_df_with_mean,
+        "meanCumulativeReward",
+        _title,
+        "Episode",
+        "Reward",
+        pp_meanCumulativeReward,
+        _subtitle="Mean Cumulative Reward (across episodes)",
+        _yalias="Mean Cumu. Reward",
         _description=_description,
         # _ema_line=True,
         # _ma_line=True


### PR DESCRIPTION
This pull request updates the logic for selecting the "best" run per group in the plotting utilities, shifting the criteria from `max_cumulative_reward` to the last episode's `currentCumulativeReward` as read from each run's `common_data.csv`. It also improves the persistence plotting by adding calculation and plotting of the mean cumulative reward per episode. These changes ensure that the evaluation of runs is more robust and based on up-to-date episode data.

**Best-of selection improvements:**
* Changed `best_of_by_group` to use the last episode's `currentCumulativeReward` (from `common_data.csv`) as the selection metric, instead of relying on the `max_cumulative_reward` column in `summary.csv`. This makes the best-of logic more accurate and robust. [[1]](diffhunk://#diff-f176b0443593d7b6d14ca5fa4a12f8a951a9188398902d5451489fc77ef95e06L131-R131) [[2]](diffhunk://#diff-f176b0443593d7b6d14ca5fa4a12f8a951a9188398902d5451489fc77ef95e06L143-L144) [[3]](diffhunk://#diff-f176b0443593d7b6d14ca5fa4a12f8a951a9188398902d5451489fc77ef95e06R197-R224) [[4]](diffhunk://#diff-f176b0443593d7b6d14ca5fa4a12f8a951a9188398902d5451489fc77ef95e06L298-R327)
* Updated logging in `run_bestof` to display the new metric (`last_episode_cumulative_reward`) instead of the old one.

**Persistence plotting enhancements:**
* Added calculation of `mean_cumulative_reward` for each run and included it in `summary.csv` and the `SUMMARY_KEYS` list. [[1]](diffhunk://#diff-b10ec6403f0a195225a520b2dbffcedd8d91bc752a93e929a49a656e6e74f04dR43) [[2]](diffhunk://#diff-b10ec6403f0a195225a520b2dbffcedd8d91bc752a93e929a49a656e6e74f04dR446-R459)
* Added a `meanCumulativeReward` column to `common_data.csv` (expanding mean over episodes) and ensured the data is sorted by episode number for correctness. [[1]](diffhunk://#diff-b10ec6403f0a195225a520b2dbffcedd8d91bc752a93e929a49a656e6e74f04dR423) [[2]](diffhunk://#diff-b10ec6403f0a195225a520b2dbffcedd8d91bc752a93e929a49a656e6e74f04dR446-R459)
* Added a new plot for mean cumulative reward per episode (`Mean Cumulative Reward.png`) to the persistence plotting output.