### PR TITLE
Option of decay episodically on epsilon greedy Behavioral Policy

### DIFF
--- a/pyrunner/batch_configs.py
+++ b/pyrunner/batch_configs.py
@@ -12,6 +12,7 @@ LIST_OF_CONFIGS = [
          "eg_ed": 0.99,        # Alternative: fast decay (ε ≈ 0.0066)
          # "eg_ed": 0.999,       # Alternative: slow decay
          "eg_me": 0.1,
+         # "eg_de": true,
      }
      },
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
@@ -19,7 +20,8 @@ LIST_OF_CONFIGS = [
          "eg_ip": 1.0,
          # "eg_ed": 0.99,
          "eg_ed": 0.991,       # Alternative: fast decay
-         # "eg_ed": 0.9991,      # Alternative: slow decay
+         # "eg_ed": 0.9991,
+         #          # "eg_de": true,      # Alternative: slow decay
          "eg_me": 0.1,
      }
      },
@@ -30,6 +32,7 @@ LIST_OF_CONFIGS = [
          "eg_ed": 0.992,       # Alternative: fast decay
          # "eg_ed": 0.9992,      # Alternative: slow decay
          "eg_me": 0.1,
+         # "eg_de": true,
      }
      },
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
@@ -39,6 +42,7 @@ LIST_OF_CONFIGS = [
          "eg_ed": 0.993,       # Alternative: fast decay
          # "eg_ed": 0.9993,      # Alternative: slow decay
          "eg_me": 0.1,
+         # "eg_de": true,
      }
      },
 
@@ -49,6 +53,7 @@ LIST_OF_CONFIGS = [
          "eg_ed": 0.994,       # Alternative: fast decay
          # "eg_ed": 0.9994,      # Alternative: slow decay
          "eg_me": 0.1,
+         # "eg_de": true,
      }
      },
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
@@ -58,6 +63,7 @@ LIST_OF_CONFIGS = [
          "eg_ed": 0.9954,      # Alternative: fast decay
          # "eg_ed": 0.9995,      # Alternative: slow decay
          "eg_me": 0.1,
+         # "eg_de": true,
      }
      },
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
@@ -67,6 +73,7 @@ LIST_OF_CONFIGS = [
          "eg_ed": 0.996,       # Alternative: fast decay
          # "eg_ed": 0.9996,      # Alternative: slow decay
          "eg_me": 0.1,
+         # "eg_de": true,
      }
      },
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
@@ -76,6 +83,7 @@ LIST_OF_CONFIGS = [
          "eg_ed": 0.997,       # Alternative: fast decay
          # "eg_ed": 0.9997,      # Alternative: slow decay
          "eg_me": 0.1,
+         # "eg_de": true,
      }
      },
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
@@ -85,6 +93,7 @@ LIST_OF_CONFIGS = [
          "eg_ed": 0.998,       # Alternative: fast decay
          # "eg_ed": 0.9998,      # Alternative: slow decay
          "eg_me": 0.1,
+         # "eg_de": true,
      }
      },
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
@@ -94,6 +103,7 @@ LIST_OF_CONFIGS = [
          "eg_ed": 0.999,       # Alternative: fast decay
          # "eg_ed": 0.9999,      # Alternative: slow decay
          "eg_me": 0.1,
+         # "eg_de": true,
      }
      },
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
@@ -103,6 +113,7 @@ LIST_OF_CONFIGS = [
          "eg_ed": 0.9991,      # Alternative: fast decay
          # "eg_ed": 0.99991,     # Alternative: slow decay
          "eg_me": 0.1,
+         # "eg_de": true,
      }
      },
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
@@ -112,6 +123,7 @@ LIST_OF_CONFIGS = [
          "eg_ed": 0.9992,      # Alternative: fast decay
          # "eg_ed": 0.99992,     # Alternative: slow decay
          "eg_me": 0.1,
+         # "eg_de": true,
      }
      },
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
@@ -121,6 +133,7 @@ LIST_OF_CONFIGS = [
          "eg_ed": 0.9993,      # Alternative: fast decay
          # "eg_ed": 0.99993,     # Alternative: slow decay
          "eg_me": 0.1,
+         # "eg_de": true,
      }
      },
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
@@ -130,6 +143,7 @@ LIST_OF_CONFIGS = [
          "eg_ed": 0.9994,      # Alternative: fast decay
          # "eg_ed": 0.99994,     # Alternative: slow decay
          "eg_me": 0.1,
+         # "eg_de": true,
      }
      },
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
@@ -139,6 +153,7 @@ LIST_OF_CONFIGS = [
          "eg_ed": 0.9995,      # Alternative: fast decay
          # "eg_ed": 0.99995,     # Alternative: slow decay
          "eg_me": 0.1,
+         # "eg_de": true,
      }
      },
 

--- a/pyrunner/batch_configs.py
+++ b/pyrunner/batch_configs.py
@@ -2,16 +2,14 @@
 The list of configurations for the batch runner. Starts from index 0.
 """
 
-from decimal import Decimal
-
 LIST_OF_CONFIGS = [
     # [ Q-Learning with Epsilon-Greedy ] (indices 0-14)
     # Decay formula: epsilon = max(0.1, epsilon × d) | 500 episodes: 0.99x (fast), 0.994-0.996 (balanced), 0.997-0.999x (slow)
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
      "overrides": {
          "eg_ip": 1.0,
-         "eg_ed": 0.9,
-         # "eg_ed": 0.99,        # Alternative: fast decay (ε ≈ 0.0066)
+         # "eg_ed": 0.9,
+         "eg_ed": 0.99,        # Alternative: fast decay (ε ≈ 0.0066)
          # "eg_ed": 0.999,       # Alternative: slow decay
          "eg_me": 0.1,
      }
@@ -19,8 +17,8 @@ LIST_OF_CONFIGS = [
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
      "overrides": {
          "eg_ip": 1.0,
-         "eg_ed": 0.99,
-         # "eg_ed": 0.991,       # Alternative: fast decay
+         # "eg_ed": 0.99,
+         "eg_ed": 0.991,       # Alternative: fast decay
          # "eg_ed": 0.9991,      # Alternative: slow decay
          "eg_me": 0.1,
      }
@@ -28,8 +26,8 @@ LIST_OF_CONFIGS = [
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
      "overrides": {
          "eg_ip": 1.0,
-         "eg_ed": 0.999,
-         # "eg_ed": 0.992,       # Alternative: fast decay
+         # "eg_ed": 0.999,
+         "eg_ed": 0.992,       # Alternative: fast decay
          # "eg_ed": 0.9992,      # Alternative: slow decay
          "eg_me": 0.1,
      }
@@ -37,8 +35,8 @@ LIST_OF_CONFIGS = [
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
      "overrides": {
          "eg_ip": 1.0,
-         "eg_ed": 0.9999,
-         # "eg_ed": 0.993,       # Alternative: fast decay
+         # "eg_ed": 0.9999,
+         "eg_ed": 0.993,       # Alternative: fast decay
          # "eg_ed": 0.9993,      # Alternative: slow decay
          "eg_me": 0.1,
      }
@@ -47,8 +45,8 @@ LIST_OF_CONFIGS = [
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
      "overrides": {
          "eg_ip": 1.0,
-         "eg_ed": 0.99999,
-         # "eg_ed": 0.994,       # Alternative: fast decay
+         # "eg_ed": 0.99999,
+         "eg_ed": 0.994,       # Alternative: fast decay
          # "eg_ed": 0.9994,      # Alternative: slow decay
          "eg_me": 0.1,
      }
@@ -56,8 +54,8 @@ LIST_OF_CONFIGS = [
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
      "overrides": {
          "eg_ip": 1.0,
-         "eg_ed": 0.999999,
-         # "eg_ed": 0.9954,      # Alternative: fast decay
+         # "eg_ed": 0.999999,
+         "eg_ed": 0.9954,      # Alternative: fast decay
          # "eg_ed": 0.9995,      # Alternative: slow decay
          "eg_me": 0.1,
      }
@@ -65,8 +63,8 @@ LIST_OF_CONFIGS = [
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
      "overrides": {
          "eg_ip": 1.0,
-         "eg_ed": 0.9999999,
-         # "eg_ed": 0.996,       # Alternative: fast decay
+         # "eg_ed": 0.9999999,
+         "eg_ed": 0.996,       # Alternative: fast decay
          # "eg_ed": 0.9996,      # Alternative: slow decay
          "eg_me": 0.1,
      }
@@ -74,8 +72,8 @@ LIST_OF_CONFIGS = [
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
      "overrides": {
          "eg_ip": 1.0,
-         "eg_ed": 0.99999999,
-         # "eg_ed": 0.997,       # Alternative: fast decay
+         # "eg_ed": 0.99999999,
+         "eg_ed": 0.997,       # Alternative: fast decay
          # "eg_ed": 0.9997,      # Alternative: slow decay
          "eg_me": 0.1,
      }
@@ -83,8 +81,8 @@ LIST_OF_CONFIGS = [
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
      "overrides": {
          "eg_ip": 1.0,
-         "eg_ed": 0.999999999,
-         # "eg_ed": 0.998,       # Alternative: fast decay
+         # "eg_ed": 0.999999999,
+         "eg_ed": 0.998,       # Alternative: fast decay
          # "eg_ed": 0.9998,      # Alternative: slow decay
          "eg_me": 0.1,
      }
@@ -92,8 +90,8 @@ LIST_OF_CONFIGS = [
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
      "overrides": {
          "eg_ip": 1.0,
-         "eg_ed": 0.9999999999,
-         # "eg_ed": 0.999,       # Alternative: fast decay
+         # "eg_ed": 0.9999999999,
+         "eg_ed": 0.999,       # Alternative: fast decay
          # "eg_ed": 0.9999,      # Alternative: slow decay
          "eg_me": 0.1,
      }
@@ -101,8 +99,8 @@ LIST_OF_CONFIGS = [
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
      "overrides": {
          "eg_ip": 1.0,
-         "eg_ed": 0.99999999999,
-         # "eg_ed": 0.9991,      # Alternative: fast decay
+         # "eg_ed": 0.99999999999,
+         "eg_ed": 0.9991,      # Alternative: fast decay
          # "eg_ed": 0.99991,     # Alternative: slow decay
          "eg_me": 0.1,
      }
@@ -110,8 +108,8 @@ LIST_OF_CONFIGS = [
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
      "overrides": {
          "eg_ip": 1.0,
-         "eg_ed": 0.999999999999,
-         # "eg_ed": 0.9992,      # Alternative: fast decay
+         # "eg_ed": 0.999999999999,
+         "eg_ed": 0.9992,      # Alternative: fast decay
          # "eg_ed": 0.99992,     # Alternative: slow decay
          "eg_me": 0.1,
      }
@@ -119,8 +117,8 @@ LIST_OF_CONFIGS = [
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
      "overrides": {
          "eg_ip": 1.0,
-         "eg_ed": 0.9999999999999,
-         # "eg_ed": 0.9993,      # Alternative: fast decay
+         # "eg_ed": 0.9999999999999,
+         "eg_ed": 0.9993,      # Alternative: fast decay
          # "eg_ed": 0.99993,     # Alternative: slow decay
          "eg_me": 0.1,
      }
@@ -128,8 +126,8 @@ LIST_OF_CONFIGS = [
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
      "overrides": {
          "eg_ip": 1.0,
-         "eg_ed": 0.99999999999999,
-         # "eg_ed": 0.9994,      # Alternative: fast decay
+         # "eg_ed": 0.99999999999999,
+         "eg_ed": 0.9994,      # Alternative: fast decay
          # "eg_ed": 0.99994,     # Alternative: slow decay
          "eg_me": 0.1,
      }
@@ -137,8 +135,8 @@ LIST_OF_CONFIGS = [
     {"alg": "ql", "runs": 500, "bp": "epsilon", "id": "ql5-bp=epsilon",
      "overrides": {
          "eg_ip": 1.0,
-         "eg_ed": 0.999999999999999,
-         # "eg_ed": 0.9995,      # Alternative: fast decay
+         # "eg_ed": 0.999999999999999,
+         "eg_ed": 0.9995,      # Alternative: fast decay
          # "eg_ed": 0.99995,     # Alternative: slow decay
          "eg_me": 0.1,
      }

--- a/pyrunner/term_dictionary.py
+++ b/pyrunner/term_dictionary.py
@@ -65,6 +65,7 @@ KEY_ABBREVIATIONS = {
     "eg_ip": "BehaviorPolicy.EpsilonGreedy.epsilon",
     "eg_ed": "BehaviorPolicy.EpsilonGreedy.epsilonDecay",
     "eg_me": "BehaviorPolicy.EpsilonGreedy.minEpsilon",
+    "eg_de": "BehaviorPolicy.EpsilonGreedy.decayEpisodically",
 
     # [ UCBBehavior settings ]
     "ucb_ec": "BehaviorPolicy.UCB.explorationConstant",

--- a/settings/skripsi/randomsearch-qlearn-ql-c-ms@0.cfg
+++ b/settings/skripsi/randomsearch-qlearn-ql-c-ms@0.cfg
@@ -116,6 +116,7 @@ QLearningMovement.learningSeed = 0
 BehaviorPolicy.EpsilonGreedy.epsilon = 1
 BehaviorPolicy.EpsilonGreedy.epsilonDecay = 0.999999
 BehaviorPolicy.EpsilonGreedy.minEpsilon = 0.1
+BehaviorPolicy.EpsilonGreedy.decayEpisodically = true
 
 [ UCBBehavior settings ]
 BehaviorPolicy.UCB.explorationConstant = 2

--- a/settings/skripsi/randomsearch-qlearn-ql-c-ms@1.cfg
+++ b/settings/skripsi/randomsearch-qlearn-ql-c-ms@1.cfg
@@ -116,6 +116,7 @@ QLearningMovement.learningSeed = 0
 BehaviorPolicy.EpsilonGreedy.epsilon = 1
 BehaviorPolicy.EpsilonGreedy.epsilonDecay = 0.999999
 BehaviorPolicy.EpsilonGreedy.minEpsilon = 0.1
+BehaviorPolicy.EpsilonGreedy.decayEpisodically = true
 
 [ UCBBehavior settings ]
 BehaviorPolicy.UCB.explorationConstant = 2

--- a/settings/skripsi/randomsearch-qlearn-ql-p-ms@0.cfg
+++ b/settings/skripsi/randomsearch-qlearn-ql-p-ms@0.cfg
@@ -116,6 +116,7 @@ QLearningMovement.learningSeed = 0
 BehaviorPolicy.EpsilonGreedy.epsilon = 1
 BehaviorPolicy.EpsilonGreedy.epsilonDecay = 0.999999
 BehaviorPolicy.EpsilonGreedy.minEpsilon = 0.1
+BehaviorPolicy.EpsilonGreedy.decayEpisodically = true
 
 [ UCBBehavior settings ]
 BehaviorPolicy.UCB.explorationConstant = 2

--- a/settings/skripsi/randomsearch-qlearn-ql-p-ms@1.cfg
+++ b/settings/skripsi/randomsearch-qlearn-ql-p-ms@1.cfg
@@ -116,6 +116,7 @@ QLearningMovement.learningSeed = 0
 BehaviorPolicy.EpsilonGreedy.epsilon = 1
 BehaviorPolicy.EpsilonGreedy.epsilonDecay = 0.999999
 BehaviorPolicy.EpsilonGreedy.minEpsilon = 0.1
+BehaviorPolicy.EpsilonGreedy.decayEpisodically = true
 
 [ UCBBehavior settings ]
 BehaviorPolicy.UCB.explorationConstant = 2

--- a/src/movement/rl/behavior/EpsilonGreedyBehavior.java
+++ b/src/movement/rl/behavior/EpsilonGreedyBehavior.java
@@ -19,12 +19,14 @@ public class EpsilonGreedyBehavior implements BehaviorPolicy {
 	private double epsilon;
 	private final double epsilonDecay;
 	private final double minEpsilon;
+	private final boolean decayEpisodically;
 	private Random random;
 
 	public static final String BEHAVIOR_NS = "BehaviorPolicy.EpsilonGreedy";
 	public static final String EPSILON_S = "epsilon";
 	public static final String DECAY_S = "epsilonDecay";
 	public static final String MIN_EPSILON_S = "minEpsilon";
+	public static final String DECAY_EPISODICALLY_S = "decayEpisodically";
 
 	/**
 	 * Constructor called reflectively by Settings. The {@code _settings} param is unused
@@ -36,6 +38,7 @@ public class EpsilonGreedyBehavior implements BehaviorPolicy {
 		this.epsilon = behaviorSettings.getDouble(EPSILON_S, 0.9);
 		this.epsilonDecay = behaviorSettings.getDouble(DECAY_S, 0.995);
 		this.minEpsilon = behaviorSettings.getDouble(MIN_EPSILON_S, 0.01);
+		this.decayEpisodically = behaviorSettings.getBoolean(DECAY_EPISODICALLY_S, true);
 
 		// use seed from MovementModel for reproducibility
 		this.random = MovementModel.getRandom();
@@ -50,6 +53,7 @@ public class EpsilonGreedyBehavior implements BehaviorPolicy {
 		this.epsilon = proto.epsilon;
 		this.epsilonDecay = proto.epsilonDecay;
 		this.minEpsilon = proto.minEpsilon;
+		this.decayEpisodically = proto.decayEpisodically;
 		this.random = proto.random;
 	}
 
@@ -79,8 +83,10 @@ public class EpsilonGreedyBehavior implements BehaviorPolicy {
 	 */
 	@Override
 	public void update(int stateId, int actionIndex, double reward, double prevQ, double prevMaxNextQ, double updatedQ) {
-		/* ε_t+1 = max(ε, ε • decay rate) */
-		epsilon = Math.max(minEpsilon, epsilon * epsilonDecay);
+		if (!decayEpisodically) {
+			/* ε_t+1 = max(ε, ε • decay rate) */
+			epsilon = Math.max(minEpsilon, epsilon * epsilonDecay);
+		}
 	}
 
 	/**
@@ -146,6 +152,10 @@ public class EpsilonGreedyBehavior implements BehaviorPolicy {
 
 	@Override
 	public void saveTo(EpisodicPersistenceData epd) {
+		if (decayEpisodically) {
+			/* ε_t+1 = max(ε, ε • decay rate) */
+			this.epsilon = Math.max(minEpsilon, epsilon * epsilonDecay);
+		}
 		epd.epsilon = this.epsilon;
 		System.out.println("[EpsilonGreedyBehavior] Saved epsilon of: " + epd.epsilon);
 	}


### PR DESCRIPTION
This pull request introduces a new configuration option, `decayEpisodically`, for the epsilon-greedy behavior policy in reinforcement learning. This option allows epsilon decay to be performed either after every step or only at the end of each episode, depending on the setting. The change is reflected across the batch configuration, the Java implementation, and relevant configuration files.

**Epsilon-Greedy Behavior Policy Enhancements:**

* Added the `decayEpisodically` boolean parameter to the `EpsilonGreedyBehavior` class, allowing users to control whether epsilon decays at each step or only at the end of episodes. The parameter is loaded from settings and copied in the copy constructor. [[1]](diffhunk://#diff-c04e46030dec4b6f071bd1f76998eb734e7b1a9ee40cbe60cdff2ac23d3b1739R22-R29) [[2]](diffhunk://#diff-c04e46030dec4b6f071bd1f76998eb734e7b1a9ee40cbe60cdff2ac23d3b1739R41) [[3]](diffhunk://#diff-c04e46030dec4b6f071bd1f76998eb734e7b1a9ee40cbe60cdff2ac23d3b1739R56)
* Modified the epsilon update logic: if `decayEpisodically` is `false`, epsilon decays after every step in `update`; if `true`, decay occurs only in `saveTo` (which is called at the end of episodes). [[1]](diffhunk://#diff-c04e46030dec4b6f071bd1f76998eb734e7b1a9ee40cbe60cdff2ac23d3b1739R86-R90) [[2]](diffhunk://#diff-c04e46030dec4b6f071bd1f76998eb734e7b1a9ee40cbe60cdff2ac23d3b1739R155-R158)
* Exposed the new parameter in the term dictionary for configuration mapping (`eg_de`).

**Configuration and Batch Updates:**

* Updated `batch_configs.py` to add commented-out `eg_de` options in epsilon-greedy batch configurations, allowing easy toggling of episodic decay for different experiments.
* Updated multiple experiment configuration files to explicitly set `BehaviorPolicy.EpsilonGreedy.decayEpisodically = true`, ensuring episodic decay is enabled in those runs. [[1]](diffhunk://#diff-85ef16f1cc57b0766ee5fbb8dea5b415101f7ec86aa618de821747c84e6952ebR119) [[2]](diffhunk://#diff-0d8789353bf6342de9b3d5f08d785c95929dce0cd410ad5fd878c544238aaf41R119) [[3]](diffhunk://#diff-d557d456c58f4c7f2362671bc527ef9cf37b6ca491e39aea0ed402d11916c5ecR119) [[4]](diffhunk://#diff-8193d69820d8f5d179eeb42fbaf22268104891696f44b93d8fc5e51e909f6d2eR119)