### PR TITLE
Support directly calling the file

### DIFF
--- a/PLOTTER_SHEET.md
+++ b/PLOTTER_SHEET.md
@@ -3,14 +3,14 @@
 ## Persistence Plotters
 
 ```sh
-python -m pyplotters.persistence_plotter -aof lfe-c-ms@0 --title "Lévy Flight on Stochastic Stationary Clustered Distributed Targets" --describe
-python -m pyplotters.persistence_plotter -aof lfe-c-ms@1 --title "Lévy Flight on Fixed Stationary Clustered Distributed Targets" --describe
-python -m pyplotters.persistence_plotter -aof lfe-p-ms@0 --title "Lévy Flight on Stochastic Stationary Poisson Distributed Targets" --describe
-python -m pyplotters.persistence_plotter -aof lfe-p-ms@1 --title "Lévy Flight on Fixed Stationary Poisson Distributed Targets" --describe
-python -m pyplotters.persistence_plotter -aof ql-c-ms@0 --title "Q-Learning on Stochastic Stationary Clustered Distributed Targets" --describe
-python -m pyplotters.persistence_plotter -aof ql-c-ms@1 --title "Q-Learning on Fixed Stationary Clustered Distributed Targets" --describe
-python -m pyplotters.persistence_plotter -aof ql-p-ms@0 --title "Q-Learning on Stochastic Stationary Poisson Distributed Targets" --describe
-python -m pyplotters.persistence_plotter -aof ql-p-ms@1 --title "Q-Learning on Fixed Stationary Poisson Distributed Targets" --describe
+python pyplotters/persistence_plotter.py -aof lfe-c-ms@0 --title "Lévy Flight on Stochastic Stationary Clustered Distributed Targets" --describe
+python pyplotters/persistence_plotter.py -aof lfe-c-ms@1 --title "Lévy Flight on Fixed Stationary Clustered Distributed Targets" --describe
+python pyplotters/persistence_plotter.py -aof lfe-p-ms@0 --title "Lévy Flight on Stochastic Stationary Poisson Distributed Targets" --describe
+python pyplotters/persistence_plotter.py -aof lfe-p-ms@1 --title "Lévy Flight on Fixed Stationary Poisson Distributed Targets" --describe
+python pyplotters/persistence_plotter.py -aof ql-c-ms@0 --title "Q-Learning on Stochastic Stationary Clustered Distributed Targets" --describe
+python pyplotters/persistence_plotter.py -aof ql-c-ms@1 --title "Q-Learning on Fixed Stationary Clustered Distributed Targets" --describe
+python pyplotters/persistence_plotter.py -aof ql-p-ms@0 --title "Q-Learning on Stochastic Stationary Poisson Distributed Targets" --describe
+python pyplotters/persistence_plotter.py -aof ql-p-ms@1 --title "Q-Learning on Fixed Stationary Poisson Distributed Targets" --describe
 
 ```
 
@@ -19,30 +19,30 @@ python -m pyplotters.persistence_plotter -aof ql-p-ms@1 --title "Q-Learning on F
 ### Levy Flight Episodic
 
 ```sh
-python -m pyplotters.bestof_plotter -aof lfe-c-ms@0 --group lfe_la
-python -m pyplotters.bestof_plotter -aof lfe-c-ms@1 --group lfe_la
-python -m pyplotters.bestof_plotter -aof lfe-p-ms@0 --group lfe_la
-python -m pyplotters.bestof_plotter -aof lfe-p-ms@1 --group lfe_la
+python pyplotters/bestof_plotter.py -aof lfe-c-ms@0 --group lfe_la
+python pyplotters/bestof_plotter.py -aof lfe-c-ms@1 --group lfe_la
+python pyplotters/bestof_plotter.py -aof lfe-p-ms@0 --group lfe_la
+python pyplotters/bestof_plotter.py -aof lfe-p-ms@1 --group lfe_la
 
 ```
 
 ### Q-Learning
 
 ```sh
-python -m pyplotters.bestof_plotter -aof ql-c-ms@0 --group qlm_bp --addparams qlm_bp@lfe --title "Lévy Flight vs Q-Learning with Behavior Policy Comparison"
-python -m pyplotters.bestof_plotter -aof ql-c-ms@1 --group qlm_bp --addparams qlm_bp@lfe --title "Lévy Flight vs Q-Learning with Behavior Policy Comparison"
-python -m pyplotters.bestof_plotter -aof ql-p-ms@0 --group qlm_bp --addparams qlm_bp@lfe --title "Lévy Flight vs Q-Learning with Behavior Policy Comparison"
-python -m pyplotters.bestof_plotter -aof ql-p-ms@1 --group qlm_bp --addparams qlm_bp@lfe --title "Lévy Flight vs Q-Learning with Behavior Policy Comparison"
+python pyplotters/bestof_plotter.py -aof ql-c-ms@0 --group qlm_bp --addparams qlm_bp@lfe --title "Lévy Flight vs Q-Learning with Behavior Policy Comparison"
+python pyplotters/bestof_plotter.py -aof ql-c-ms@1 --group qlm_bp --addparams qlm_bp@lfe --title "Lévy Flight vs Q-Learning with Behavior Policy Comparison"
+python pyplotters/bestof_plotter.py -aof ql-p-ms@0 --group qlm_bp --addparams qlm_bp@lfe --title "Lévy Flight vs Q-Learning with Behavior Policy Comparison"
+python pyplotters/bestof_plotter.py -aof ql-p-ms@1 --group qlm_bp --addparams qlm_bp@lfe --title "Lévy Flight vs Q-Learning with Behavior Policy Comparison"
 
 ```
 
 ## Merging LFE run ids to QL
 
 ```sh
-python -m pyplotters.summary_merger -mf lfe-c-ms@0 -mt ql-c-ms@0 --mvplots
-python -m pyplotters.summary_merger -mf lfe-c-ms@1 -mt ql-c-ms@1 --mvplots
-python -m pyplotters.summary_merger -mf lfe-p-ms@0 -mt ql-p-ms@0 --mvplots
-python -m pyplotters.summary_merger -mf lfe-p-ms@1 -mt ql-p-ms@1 --mvplots
+python pyplotters/summary_merger.py -mf lfe-c-ms@0 -mt ql-c-ms@0 --mvplots
+python pyplotters/summary_merger.py -mf lfe-c-ms@1 -mt ql-c-ms@1 --mvplots
+python pyplotters/summary_merger.py -mf lfe-p-ms@0 -mt ql-p-ms@0 --mvplots
+python pyplotters/summary_merger.py -mf lfe-p-ms@1 -mt ql-p-ms@1 --mvplots
 
 ```
 

--- a/RUNNER_SHEET.md
+++ b/RUNNER_SHEET.md
@@ -3,14 +3,14 @@
 ## Overall running with different ALG overriding
 
 ```sh
-python -m pyrunner.batch_runner -pid ql-c-ms@0 -c 0-30 -alg ql-c-ms@0
-python -m pyrunner.batch_runner -pid ql-c-ms@1 -c 0-30 -alg ql-c-ms@1
-python -m pyrunner.batch_runner -pid ql-p-ms@0 -c 0-30 -alg ql-p-ms@0
-python -m pyrunner.batch_runner -pid ql-p-ms@1 -c 0-30 -alg ql-p-ms@1
-python -m pyrunner.batch_runner -pid lfe-c-ms@0 -c 31-38 -alg lfe-c-ms@0
-python -m pyrunner.batch_runner -pid lfe-c-ms@1 -c 31-38 -alg lfe-c-ms@1
-python -m pyrunner.batch_runner -pid lfe-p-ms@0 -c 31-38 -alg lfe-p-ms@0
-python -m pyrunner.batch_runner -pid lfe-p-ms@1 -c 31-38 -alg lfe-p-ms@1
+python pyrunner/batch_runner.py -pid ql-c-ms@0 -c 0-30 -alg ql-c-ms@0
+python pyrunner/batch_runner.py -pid ql-c-ms@1 -c 0-30 -alg ql-c-ms@1
+python pyrunner/batch_runner.py -pid ql-p-ms@0 -c 0-30 -alg ql-p-ms@0
+python pyrunner/batch_runner.py -pid ql-p-ms@1 -c 0-30 -alg ql-p-ms@1
+python pyrunner/batch_runner.py -pid lfe-c-ms@0 -c 31-38 -alg lfe-c-ms@0
+python pyrunner/batch_runner.py -pid lfe-c-ms@1 -c 31-38 -alg lfe-c-ms@1
+python pyrunner/batch_runner.py -pid lfe-p-ms@0 -c 31-38 -alg lfe-p-ms@0
+python pyrunner/batch_runner.py -pid lfe-p-ms@1 -c 31-38 -alg lfe-p-ms@1
 
 ```
 
@@ -19,40 +19,40 @@ python -m pyrunner.batch_runner -pid lfe-p-ms@1 -c 31-38 -alg lfe-p-ms@1
 ### Running Epsilon Greedy Configs
 
 ```sh
-python -m pyrunner.batch_runner -pid ql-c-ms@0 -c 0-13
-python -m pyrunner.batch_runner -pid ql-c-ms@1 -c 0-13
-python -m pyrunner.batch_runner -pid ql-p-ms@0 -c 0-13
-python -m pyrunner.batch_runner -pid ql-p-ms@1 -c 0-13
+python pyrunner/batch_runner.py -pid ql-c-ms@0 -c 0-13
+python pyrunner/batch_runner.py -pid ql-c-ms@1 -c 0-13
+python pyrunner/batch_runner.py -pid ql-p-ms@0 -c 0-13
+python pyrunner/batch_runner.py -pid ql-p-ms@1 -c 0-13
 
 ```
 
 ### Running Upper Confidence Bound Configs
 
 ```sh
-python -m pyrunner.batch_runner -pid ql-c-ms@0 -c 14-25
-python -m pyrunner.batch_runner -pid ql-c-ms@1 -c 14-25
-python -m pyrunner.batch_runner -pid ql-p-ms@0 -c 14-25
-python -m pyrunner.batch_runner -pid ql-p-ms@1 -c 14-25
+python pyrunner/batch_runner.py -pid ql-c-ms@0 -c 14-25
+python pyrunner/batch_runner.py -pid ql-c-ms@1 -c 14-25
+python pyrunner/batch_runner.py -pid ql-p-ms@0 -c 14-25
+python pyrunner/batch_runner.py -pid ql-p-ms@1 -c 14-25
 
 ```
 
 ### Running Thompson Sampling Configs
 
 ```sh
-python -m pyrunner.batch_runner -pid ql-c-ms@0 -c 26-30
-python -m pyrunner.batch_runner -pid ql-c-ms@1 -c 26-30
-python -m pyrunner.batch_runner -pid ql-p-ms@0 -c 26-30
-python -m pyrunner.batch_runner -pid ql-p-ms@1 -c 26-30
+python pyrunner/batch_runner.py -pid ql-c-ms@0 -c 26-30
+python pyrunner/batch_runner.py -pid ql-c-ms@1 -c 26-30
+python pyrunner/batch_runner.py -pid ql-p-ms@0 -c 26-30
+python pyrunner/batch_runner.py -pid ql-p-ms@1 -c 26-30
 
 ```
 
 ### Running Lévy Flight Configs
 
 ```sh
-python -m pyrunner.batch_runner -pid lfe-c-ms@0 -c 31-38
-python -m pyrunner.batch_runner -pid lfe-c-ms@1 -c 31-38
-python -m pyrunner.batch_runner -pid lfe-p-ms@0 -c 31-38
-python -m pyrunner.batch_runner -pid lfe-p-ms@1 -c 31-38
+python pyrunner/batch_runner.py -pid lfe-c-ms@0 -c 31-38
+python pyrunner/batch_runner.py -pid lfe-c-ms@1 -c 31-38
+python pyrunner/batch_runner.py -pid lfe-p-ms@0 -c 31-38
+python pyrunner/batch_runner.py -pid lfe-p-ms@1 -c 31-38
 
 ```
 

--- a/pyrunner/batch_runner.py
+++ b/pyrunner/batch_runner.py
@@ -16,14 +16,15 @@ import time
 from datetime import datetime, timedelta
 from typing import Optional, Tuple, Any
 
-from pyrunner.term_dictionary import KEY_ABBREVIATIONS, BEHAVIOR_PACKAGES, ALG_BASE_SETTINGS_PATH, ALG_ABBREVIATIONS
-from pyrunner.config_parser import parse_config_file, extract_highlighted_settings
-
 # Allow running this file as a script (python pyrunner/batch_runner.py) while still
 # using absolute package imports (pyrunner.*).
+#
+# Important: this must run *before* importing pyrunner.*
 if __package__ in (None, ""):
     sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
+from pyrunner.term_dictionary import KEY_ABBREVIATIONS, BEHAVIOR_PACKAGES, ALG_BASE_SETTINGS_PATH, ALG_ABBREVIATIONS
+from pyrunner.config_parser import parse_config_file, extract_highlighted_settings
 from pyrunner.utils.fs import safe_int_dirnames
 from pyrunner.utils.jsonio import load_json_file
 from pyrunner.utils.path import validate_run_id


### PR DESCRIPTION
This pull request updates several documentation files and the `batch_runner.py` script to standardize how Python scripts are invoked and to improve compatibility when running scripts directly. The main changes are:

**Documentation updates (command invocation standardization):**

* Updated all references in `PLOTTER_SHEET.md` and `RUNNER_SHEET.md` to invoke scripts using the direct path (e.g., `python pyplotters/persistence_plotter.py`) instead of the `-m` module syntax (e.g., `python -m pyplotters.persistence_plotter`). This affects commands for plotters, mergers, and runners, ensuring consistency and reducing confusion for users running scripts directly. [[1]](diffhunk://#diff-3e2b18b0f55cd62f06b94d0030d39c2976d73d0fbd32ca5d8348572f0a4ea73cL6-R13) [[2]](diffhunk://#diff-3e2b18b0f55cd62f06b94d0030d39c2976d73d0fbd32ca5d8348572f0a4ea73cL22-R45) [[3]](diffhunk://#diff-7a74b4fa5df11f2b901089df16c6571011c4e762d5894823851eb504fa16b6e1L6-R13) [[4]](diffhunk://#diff-7a74b4fa5df11f2b901089df16c6571011c4e762d5894823851eb504fa16b6e1L22-R55)

**Code compatibility improvement:**

* Modified `pyrunner/batch_runner.py` to allow the script to be run directly (e.g., `python pyrunner/batch_runner.py`) by adjusting the order of sys.path manipulation and imports. This ensures that absolute package imports work correctly regardless of how the script is executed.