### PR TITLE
Adding an episode end reset flag for the ucb and epsilon greedy

### DIFF
--- a/src/movement/rl/behavior/ThompsonSamplingBehavior.java
+++ b/src/movement/rl/behavior/ThompsonSamplingBehavior.java
@@ -29,6 +29,7 @@ public class ThompsonSamplingBehavior implements BehaviorPolicy {
 	private final double learningRate;
 	private final double initialVariance;
 	private final boolean usingBayesian;
+	private final boolean resetEpisodically;
 	private final Map<StateActionPair, TSProperty> tsProperties;
 
 	public static final String BEHAVIOR_NS = "BehaviorPolicy.TS";
@@ -52,6 +53,8 @@ public class ThompsonSamplingBehavior implements BehaviorPolicy {
 
 	public static final String USING_BAYESIAN_S = "usingBayesian";
 
+	public static final String RESET_EPISODICALLY_S = "resetEpisodically";
+
 	/**
 	 * Constructor called reflectively by Settings. The {@code _settings} param is unused
 	 * because this policy reads its own sub-namespace ({@value #BEHAVIOR_NS}).
@@ -71,6 +74,7 @@ public class ThompsonSamplingBehavior implements BehaviorPolicy {
 		this.learningRate = behaviorSettings.getDouble(LEARNING_RATE_S, 0.01);
 		this.initialVariance = behaviorSettings.getDouble(INITIAL_VARIANCE_S, 1.0);
 		this.usingBayesian = behaviorSettings.getBoolean(USING_BAYESIAN_S, false);
+		this.resetEpisodically = behaviorSettings.getBoolean(RESET_EPISODICALLY_S, false);
 		this.tsProperties = new HashMap<>();
 	}
 
@@ -80,6 +84,7 @@ public class ThompsonSamplingBehavior implements BehaviorPolicy {
 		this.learningRate = proto.learningRate;
 		this.initialVariance = proto.initialVariance;
 		this.usingBayesian = proto.usingBayesian;
+		this.resetEpisodically = proto.resetEpisodically;
 		this.tsProperties = new HashMap<>(proto.tsProperties);
 	}
 
@@ -274,16 +279,22 @@ public class ThompsonSamplingBehavior implements BehaviorPolicy {
 
 	@Override
 	public void loadFrom(EpisodicPersistenceData epd) {
-		// Load Thompson Sampling state variables from persistence data
-		tsProperties.clear();
+		if (!resetEpisodically) {
+			// Load Thompson Sampling state variables from persistence data
+			tsProperties.clear();
 
-		if (epd.tsProperties != null) {
-			for (var entry : epd.tsProperties.entrySet()) {
-				StateActionPair pair = StateActionPair.fromJsonKey(entry.getKey());
-				TSProperty prop = TSProperty.fromJsonValue(entry.getValue());
+			if (epd.tsProperties != null) {
+				for (var entry : epd.tsProperties.entrySet()) {
+					StateActionPair pair = StateActionPair.fromJsonKey(entry.getKey());
+					TSProperty prop = TSProperty.fromJsonValue(entry.getValue());
 
-				tsProperties.put(pair, prop);
+					tsProperties.put(pair, prop);
+				}
 			}
+		} else {
+			tsProperties.clear();
+
+			System.out.println("[ThompsonSamplingBehavior] Episodic data is not loaded. Reset episodically is TRUE.");
 		}
 	}
 

--- a/src/movement/rl/behavior/UCBBehavior.java
+++ b/src/movement/rl/behavior/UCBBehavior.java
@@ -16,196 +16,205 @@ import java.util.*;
  * - c is the exploration constant
  * - N(s) is the total number of times state s has been visited
  * - N(s,a) is the number of times action a has been selected in state s
- *
+ * <p>
  * Unvisited actions (N(s,a) = 0) receive infinite UCB bonus and are prioritized.
  *
  * @author narwa
  */
 public class UCBBehavior implements BehaviorPolicy {
 
-	private double explorationConstant;
-	private final Map<StateActionPair, Integer> stateActionFrequencies;
-	private final Map<Integer, Integer> stateFrequencies;
-	private Random random;
+    private double explorationConstant;
+    private boolean resetEpisodically;
+    private final Map<StateActionPair, Integer> stateActionFrequencies;
+    private final Map<Integer, Integer> stateFrequencies;
+    private Random random;
 
-	public static final String BEHAVIOR_NS = "BehaviorPolicy.UCB";
-	public static final String EXPLORATION_CONSTANT_S = "explorationConstant";
+    public static final String BEHAVIOR_NS = "BehaviorPolicy.UCB";
+    public static final String EXPLORATION_CONSTANT_S = "explorationConstant";
+    public static final String RESET_EPISODICALLY_S = "resetEpisodically";
 
-	/**
-	 * Constructor called reflectively by Settings. The {@code _settings} param is unused
-	 * because this policy reads its own sub-namespace ({@value #BEHAVIOR_NS}).
-	 */
-	public UCBBehavior(Settings _settings) {
-		Settings behaviorSettings = new Settings(BEHAVIOR_NS);
-		this.explorationConstant = behaviorSettings.getDouble(EXPLORATION_CONSTANT_S, 1.0);
+    /**
+     * Constructor called reflectively by Settings. The {@code _settings} param is unused
+     * because this policy reads its own sub-namespace ({@value #BEHAVIOR_NS}).
+     */
+    public UCBBehavior(Settings _settings) {
+        Settings behaviorSettings = new Settings(BEHAVIOR_NS);
+        this.explorationConstant = behaviorSettings.getDouble(EXPLORATION_CONSTANT_S, 1.0);
+        this.resetEpisodically = behaviorSettings.getBoolean(RESET_EPISODICALLY_S, true);
 
-		this.stateActionFrequencies = new HashMap<>();
-		this.stateFrequencies = new HashMap<>();
+        this.stateActionFrequencies = new HashMap<>();
+        this.stateFrequencies = new HashMap<>();
 
-		// use seed from MovementModel for reproducibility
-		this.random = MovementModel.getRandom();
-		// failsafe in case MovementModel's random is not properly initialized
-		if (this.random == null) {
-			System.out.println("Warning: MovementModel random not initialized, using new Random() for UCBBehavior");
-			this.random = new Random();
-		}
-	}
+        // use seed from MovementModel for reproducibility
+        this.random = MovementModel.getRandom();
+        // failsafe in case MovementModel's random is not properly initialized
+        if (this.random == null) {
+            System.out.println("Warning: MovementModel random not initialized, using new Random() for UCBBehavior");
+            this.random = new Random();
+        }
+    }
 
-	public UCBBehavior(UCBBehavior proto) {
-		this.explorationConstant = proto.explorationConstant;
-		this.random = proto.random;
-		this.stateActionFrequencies = new HashMap<>(proto.stateActionFrequencies);
-		this.stateFrequencies = new HashMap<>(proto.stateFrequencies);
-	}
+    public UCBBehavior(UCBBehavior proto) {
+        this.explorationConstant = proto.explorationConstant;
+        this.random = proto.random;
+        this.stateActionFrequencies = new HashMap<>(proto.stateActionFrequencies);
+        this.stateFrequencies = new HashMap<>(proto.stateFrequencies);
+    }
 
-	/**
-	 * Selects an action using the UCB formula.
-	 * Unvisited actions (N(s,a) = 0) are always selected first if exists (prioritized on exploring).
-	 * Otherwise, selects the action with the highest UCB value.
-	 *
-	 * @param stateId Current state identifier
-	 * @param qValues Q-values for each action at current state
-	 * @param availableActions Set of valid actions to choose from
-	 * @return Selected action
-	 */
-	@Override
-	public Integer selectAction(int stateId, Map<Integer, Double> qValues, @NonNull Set<Integer> availableActions) {
-		/* Handle empty action set */
-		Integer[] actionArray;
+    /**
+     * Selects an action using the UCB formula.
+     * Unvisited actions (N(s,a) = 0) are always selected first if exists (prioritized on exploring).
+     * Otherwise, selects the action with the highest UCB value.
+     *
+     * @param stateId          Current state identifier
+     * @param qValues          Q-values for each action at current state
+     * @param availableActions Set of valid actions to choose from
+     * @return Selected action
+     */
+    @Override
+    public Integer selectAction(int stateId, Map<Integer, Double> qValues, @NonNull Set<Integer> availableActions) {
+        /* Handle empty action set */
+        Integer[] actionArray;
 
-		if (availableActions.isEmpty()) {
-			System.out.println("[UCBBehavior] No actions available, using default actions of 0 and 1");
-			actionArray = new Integer[]{0, 1}; // default actions
-		} else {
-			actionArray = availableActions.toArray(new Integer[0]);
-		}
+        if (availableActions.isEmpty()) {
+            System.out.println("[UCBBehavior] No actions available, using default actions of 0 and 1");
+            actionArray = new Integer[]{0, 1}; // default actions
+        } else {
+            actionArray = availableActions.toArray(new Integer[0]);
+        }
 
-		/* Get or initialize state frequency */
-		int totalStateVisits = stateFrequencies.getOrDefault(stateId, 0);
+        /* Get or initialize state frequency */
+        int totalStateVisits = stateFrequencies.getOrDefault(stateId, 0);
 
-		/* Check for unvisited actions first (N(s,a) = 0) - these has UCB bonus (is more prioritized) */
-		// Though we only have 2 RN.
-		List<Integer> unvisitedActions = new ArrayList<>();
-		for (Integer action : actionArray) {
-			StateActionPair pair = StateActionPair.of(stateId, action);
-			if (!stateActionFrequencies.containsKey(pair)) {
-				unvisitedActions.add(action);
-			}
-		}
+        /* Check for unvisited actions first (N(s,a) = 0) - these has UCB bonus (is more prioritized) */
+        // Though we only have 2 RN.
+        List<Integer> unvisitedActions = new ArrayList<>();
+        for (Integer action : actionArray) {
+            StateActionPair pair = StateActionPair.of(stateId, action);
+            if (!stateActionFrequencies.containsKey(pair)) {
+                unvisitedActions.add(action);
+            }
+        }
 
-		/* Select one randomly if there are unvisited actions. */
-		if (!unvisitedActions.isEmpty()) {
-			return unvisitedActions.get(random.nextInt(unvisitedActions.size()));
-		}
+        /* Select one randomly if there are unvisited actions. */
+        if (!unvisitedActions.isEmpty()) {
+            return unvisitedActions.get(random.nextInt(unvisitedActions.size()));
+        }
 
-		// Proceeding where actions have all been visited, now we do he real counting.
-		// Defining the variables
+        // Proceeding where actions have all been visited, now we do he real counting.
+        // Defining the variables
 
-		double lnStateVisits = Math.log(totalStateVisits);
-		double maxUcbValue = Double.NEGATIVE_INFINITY;
-		List<Integer> bestActions = new ArrayList<>();
+        double lnStateVisits = Math.log(totalStateVisits);
+        double maxUcbValue = Double.NEGATIVE_INFINITY;
+        List<Integer> bestActions = new ArrayList<>();
 
-		for (Integer action : actionArray) {
-			StateActionPair pair = StateActionPair.of(stateId, action);
-			double qValue = qValues.getOrDefault(action, 0.0);
-			int actionVisits = stateActionFrequencies.getOrDefault(pair, 1); // avoid division by zero
+        for (Integer action : actionArray) {
+            StateActionPair pair = StateActionPair.of(stateId, action);
+            double qValue = qValues.getOrDefault(action, 0.0);
+            int actionVisits = stateActionFrequencies.getOrDefault(pair, 1); // avoid division by zero
 
-			/* UCB Formula: argmax_a( Q(s,a) + c • sqrt(ln(N(s)/N(s,a) ) */
-			double ucbValue = qValue + explorationConstant * Math.sqrt(lnStateVisits / actionVisits);
+            /* UCB Formula: argmax_a( Q(s,a) + c • sqrt(ln(N(s)/N(s,a) ) */
+            double ucbValue = qValue + explorationConstant * Math.sqrt(lnStateVisits / actionVisits);
 
-			if (ucbValue > maxUcbValue) {
-				/* Clear all previous similar UCB-value and use the better one */
-				bestActions.clear();
-				bestActions.add(action);
-				maxUcbValue = ucbValue;
-			} else if (ucbValue == maxUcbValue) {
-				/* Add equally high UCB-value */
-				bestActions.add(action);
-			}
-		}
+            if (ucbValue > maxUcbValue) {
+                /* Clear all previous similar UCB-value and use the better one */
+                bestActions.clear();
+                bestActions.add(action);
+                maxUcbValue = ucbValue;
+            } else if (ucbValue == maxUcbValue) {
+                /* Add equally high UCB-value */
+                bestActions.add(action);
+            }
+        }
 
-		// Randomly select from actions with the highest UCB value
-		return bestActions.get(random.nextInt(bestActions.size()));
-	}
+        // Randomly select from actions with the highest UCB value
+        return bestActions.get(random.nextInt(bestActions.size()));
+    }
 
-	/**
-	 * Updates the visit frequency counters after an action is taken.
-	 * Increments both N(s,a) and N(s).
-	 *
-	 * @param stateId State where the action was taken
-	 * @param actionIndex Action that was taken
-	 */
-	@Override
-	public void update(int stateId, int actionIndex, double reward, double prevQ, double prevMaxNextQ, double updatedQ) {
-		StateActionPair pair = StateActionPair.of(stateId, actionIndex);
+    /**
+     * Updates the visit frequency counters after an action is taken.
+     * Increments both N(s,a) and N(s).
+     *
+     * @param stateId     State where the action was taken
+     * @param actionIndex Action that was taken
+     */
+    @Override
+    public void update(int stateId, int actionIndex, double reward, double prevQ, double prevMaxNextQ, double updatedQ) {
+        StateActionPair pair = StateActionPair.of(stateId, actionIndex);
 
-		/* Increment N(s,a) - state-action frequency by 1 */
-		stateActionFrequencies.merge(pair, 1, Integer::sum);
+        /* Increment N(s,a) - state-action frequency by 1 */
+        stateActionFrequencies.merge(pair, 1, Integer::sum);
 
-		/* Increment N(s) - state frequency by 1 */
-		stateFrequencies.merge(stateId, 1, Integer::sum);
-	}
+        /* Increment N(s) - state frequency by 1 */
+        stateFrequencies.merge(stateId, 1, Integer::sum);
+    }
 
-	@Override
-	public BehaviorPolicy replicate() {
-		return new UCBBehavior(this);
-	}
+    @Override
+    public BehaviorPolicy replicate() {
+        return new UCBBehavior(this);
+    }
 
-	@Override
-	public String getName() {
-		return "UCBBehavior(c=" + String.format("%.3f", explorationConstant) + ")";
-	}
+    @Override
+    public String getName() {
+        return "UCBBehavior(c=" + String.format("%.3f", explorationConstant) + ")";
+    }
 
-	@Override
-	public void setRandom(Random random) {
-		this.random = random;
-	}
+    @Override
+    public void setRandom(Random random) {
+        this.random = random;
+    }
 
-	@Override
-	public void saveTo(EpisodicPersistenceData epd) {
-		/* Save exploration constant */
-		epd.ucbExplorationConstant = this.explorationConstant;
+    @Override
+    public void saveTo(EpisodicPersistenceData epd) {
+        /* Save exploration constant */
+        epd.ucbExplorationConstant = this.explorationConstant;
 
-		/* Save state-action pair frequencies, combined with : */
-		epd.ucbStateActionFrequencies = new HashMap<>();
-		for (var entry : stateActionFrequencies.entrySet()) {
-			String key = entry.getKey().getStateId() + ":" + entry.getKey().getAction();
-			epd.ucbStateActionFrequencies.put(key, entry.getValue());
-		}
+        /* Save state-action pair frequencies, combined with : */
+        epd.ucbStateActionFrequencies = new HashMap<>();
+        for (var entry : stateActionFrequencies.entrySet()) {
+            String key = entry.getKey().getStateId() + ":" + entry.getKey().getAction();
+            epd.ucbStateActionFrequencies.put(key, entry.getValue());
+        }
 
-		/* Save state-action frequencies with string keys */
-		epd.ucbStateFrequencies = new HashMap<>();
-		for (var entry : stateFrequencies.entrySet()) {
-			epd.ucbStateFrequencies.put(String.valueOf(entry.getKey()), entry.getValue());
-		}
+        /* Save state-action frequencies with string keys */
+        epd.ucbStateFrequencies = new HashMap<>();
+        for (var entry : stateFrequencies.entrySet()) {
+            epd.ucbStateFrequencies.put(String.valueOf(entry.getKey()), entry.getValue());
+        }
 
-		System.out.println("[UCBBehavior] Saved exploration constant: " + epd.ucbExplorationConstant);
-	}
+        System.out.println("[UCBBehavior] Saved exploration constant: " + epd.ucbExplorationConstant);
+    }
 
-	@Override
-	public void loadFrom(EpisodicPersistenceData epd) {
-		this.explorationConstant = epd.ucbExplorationConstant;
+    @Override
+    public void loadFrom(EpisodicPersistenceData epd) {
+        if (!resetEpisodically) {
+            this.explorationConstant = epd.ucbExplorationConstant;
 
-		/* Load state-action frequencies */
-		this.stateActionFrequencies.clear();
-		if (epd.ucbStateActionFrequencies != null) {
-			for (var entry : epd.ucbStateActionFrequencies.entrySet()) {
-				String[] values = entry.getKey().split(":");
-				if (values.length == 2) { // meaning a valid state-action pair from : split
-					StateActionPair pair = StateActionPair.of(Integer.parseInt(values[0]), Integer.parseInt(values[1]));
-					this.stateActionFrequencies.put(pair, entry.getValue());
-				}
-			}
-		}
+            /* Load state-action frequencies */
+            this.stateActionFrequencies.clear();
+            if (epd.ucbStateActionFrequencies != null) {
+                for (var entry : epd.ucbStateActionFrequencies.entrySet()) {
+                    String[] values = entry.getKey().split(":");
+                    if (values.length == 2) { // meaning a valid state-action pair from : split
+                        StateActionPair pair = StateActionPair.of(Integer.parseInt(values[0]), Integer.parseInt(values[1]));
+                        this.stateActionFrequencies.put(pair, entry.getValue());
+                    }
+                }
+            }
 
-		/* Load state frequencies */
-		this.stateFrequencies.clear();
-		if (epd.ucbStateFrequencies != null) {
-			for (var entry : epd.ucbStateFrequencies.entrySet()) {
-				this.stateFrequencies.put(Integer.parseInt(entry.getKey()), entry.getValue());
-			}
-		}
+            /* Load state frequencies */
+            this.stateFrequencies.clear();
+            if (epd.ucbStateFrequencies != null) {
+                for (var entry : epd.ucbStateFrequencies.entrySet()) {
+                    this.stateFrequencies.put(Integer.parseInt(entry.getKey()), entry.getValue());
+                }
+            }
 
-		System.out.println("[UCBBehavior] Loaded exploration constant: " + this.explorationConstant);
-	}
+            System.out.println("[UCBBehavior] Loaded exploration constant: " + this.explorationConstant);
+        } else {
+            this.stateActionFrequencies.clear();
+            this.stateFrequencies.clear();
+            System.out.println("[UCBBehavior] Episodic data is not loaded. Reset episodically is TRUE");
+        }
+    }
 }


### PR DESCRIPTION
This pull request adds support for episodic resets to both the `ThompsonSamplingBehavior` and `UCBBehavior` reinforcement learning policies. The main change is the introduction of a `resetEpisodically` option, which, when enabled, prevents the loading of persistent episodic data and instead resets the internal state at the start of each episode. This allows for more flexible experimentation with episodic versus persistent learning.

**Episodic Reset Feature:**

* Added a `resetEpisodically` configuration option to both `ThompsonSamplingBehavior` and `UCBBehavior`, including corresponding string constants for settings and constructors to read the value from configuration (`Settings`). [[1]](diffhunk://#diff-e7d4674729f27a63b78837be9b3387517610286e9e042ba304eb38ca4baaef12R32) [[2]](diffhunk://#diff-e7d4674729f27a63b78837be9b3387517610286e9e042ba304eb38ca4baaef12R56-R57) [[3]](diffhunk://#diff-e7d4674729f27a63b78837be9b3387517610286e9e042ba304eb38ca4baaef12R77) [[4]](diffhunk://#diff-e7d4674729f27a63b78837be9b3387517610286e9e042ba304eb38ca4baaef12R87) [[5]](diffhunk://#diff-6da16f6705310508b99773dde7ce47ad094ae585d192b8a86ba8846728eb51e8L19-R34) [[6]](diffhunk://#diff-6da16f6705310508b99773dde7ce47ad094ae585d192b8a86ba8846728eb51e8R43)

**Persistence Handling:**

* Modified the `loadFrom` method in both behaviors to check the `resetEpisodically` flag. If `resetEpisodically` is `true`, episodic data is not loaded and the internal state is cleared instead, with a log message indicating this behavior. [[1]](diffhunk://#diff-e7d4674729f27a63b78837be9b3387517610286e9e042ba304eb38ca4baaef12R282) [[2]](diffhunk://#diff-e7d4674729f27a63b78837be9b3387517610286e9e042ba304eb38ca4baaef12R294-R298) [[3]](diffhunk://#diff-6da16f6705310508b99773dde7ce47ad094ae585d192b8a86ba8846728eb51e8R190) [[4]](diffhunk://#diff-6da16f6705310508b99773dde7ce47ad094ae585d192b8a86ba8846728eb51e8R214-R218)

Resolves #117 