### PR TITLE
feat(TS): add --continue-on-error flag and skip failing configurations

### DIFF
--- a/pyrunner/batch_runner.py
+++ b/pyrunner/batch_runner.py
@@ -275,6 +275,7 @@ def run_script(algo: str, overrides_string: str = None, ep: int = -1, custom_cfg
     script.append(expand_algorithm(algo, custom_cfg, alg_override))
 
     _start_time = None
+    _end_time = None
 
     try:
         _start_time = datetime.now()
@@ -283,12 +284,15 @@ def run_script(algo: str, overrides_string: str = None, ep: int = -1, custom_cfg
         log.info("Running episode %s for algorithm %s.", ep, algo)
         log.info("%s", "-" * LINE_LENGTH)
         log.info("Running command: %s", " ".join(script))
-        subprocess.run(script, check=True, shell=True)
+        result = subprocess.run(script, shell=True)
+        
+        if result.returncode != 0:
+            log.error("Episode %s failed with exit code: %s", ep, result.returncode)
+            return False
+        
         return True
-    except subprocess.CalledProcessError:
-        _end_time = datetime.now()
-
-        log.error("Error running episode %s for algorithm %s.", ep, algo)
+    except Exception as e:
+        log.error("Exception while running episode %s for algorithm %s: %s", ep, algo, e)
         return False
     finally:
         _end_time = datetime.now()
@@ -488,7 +492,8 @@ def run_simulation(
         parent_dir_id: Optional[str] = None,
         custom_cfg: Optional[str] = None,
         alg_override: Optional[str] = None,
-        report_base: str = REPORTS_BASE
+        report_base: str = REPORTS_BASE,
+        continue_on_error: bool = False
 ) -> bool:
     # Validate algorithm
     settings_file = expand_algorithm(alg, custom_cfg, alg_override)
@@ -637,6 +642,13 @@ def run_simulation(
             succeeds += 1
         else:
             failed += 1
+            # Stop on first error unless continue_on_error is True
+            if not continue_on_error:
+                log.warning(
+                    "Episode %s failed. Stopping config run (use --continue-on-error to override).",
+                    ep
+                )
+                break
 
     end_time = datetime.now()
 
@@ -771,6 +783,11 @@ if __name__ == "__main__":
         help="Shortcut for --verify --continue"
     )
 
+    parser.add_argument(
+        "--continue-on-error", action="store_true",
+        help="Continue running remaining episodes even if one fails. Default behavior is to stop on first error."
+    )
+
     # Parse arguments
     args = parser.parse_args()
 
@@ -823,7 +840,8 @@ if __name__ == "__main__":
                 parent_dir_id=args.parent_dir_id,
                 custom_cfg=args.runcfg,
                 alg_override=args.algorithm,
-                report_base=args.setreportspath or REPORTS_BASE
+                report_base=args.setreportspath or REPORTS_BASE,
+                continue_on_error=args.continue_on_error
             )
 
             _sim_end_time = datetime.now()
@@ -880,7 +898,8 @@ if __name__ == "__main__":
                 parent_dir_id=args.parent_dir_id,
                 custom_cfg=args.runcfg,
                 alg_override=args.algorithm,
-                report_base=args.setreportspath or REPORTS_BASE
+                report_base=args.setreportspath or REPORTS_BASE,
+                continue_on_error=args.continue_on_error
             )
 
 
@@ -903,7 +922,7 @@ if __name__ == "__main__":
         format_timedelta(avg_running_time),
     )
     log.info(
-        "[SUMMARY] Total configurations run: %s (Success: %s, Failed: %s)",
+        "[SUMMARY] Total configurations run: %s (Success: %s, Failed: %s) - Errors count as Failed",
         successes + failures,
         successes,
         failures,


### PR DESCRIPTION
This pull request adds improved error handling and a new command-line option to the batch runner, allowing users to control whether the simulation should stop or continue when an episode fails. Additionally, error reporting and logging have been enhanced for better traceability.

**Error handling and control flow improvements:**

* Added a `--continue-on-error` command-line argument to allow users to continue running remaining episodes even if one fails; by default, the runner stops on the first error.
* Updated the `run_simulation` function to accept a `continue_on_error` parameter and to halt or continue based on this setting. [[1]](diffhunk://#diff-e3cb1dfaa581e8336f13603257414272b3e29f9e2efcee44eea073e4e4b7ebe7L491-R496) [[2]](diffhunk://#diff-e3cb1dfaa581e8336f13603257414272b3e29f9e2efcee44eea073e4e4b7ebe7R645-R651) [[3]](diffhunk://#diff-e3cb1dfaa581e8336f13603257414272b3e29f9e2efcee44eea073e4e4b7ebe7L826-R844) [[4]](diffhunk://#diff-e3cb1dfaa581e8336f13603257414272b3e29f9e2efcee44eea073e4e4b7ebe7L883-R902)
* Improved error handling in `run_script` by checking the subprocess return code, logging errors with exit codes, and only catching general exceptions for unexpected errors.

**Logging and reporting enhancements:**

* Clarified the summary log message to indicate that errors are counted as failures.
* Added initialization for the `_end_time` variable to ensure it's always defined.