### PR TITLE
Feat/137 add puasetraining parameter to pause overall training

### DIFF
--- a/settings/skripsi/randomsearch-mcn-mc-c-ms@0.cfg
+++ b/settings/skripsi/randomsearch-mcn-mc-c-ms@0.cfg
@@ -117,6 +117,8 @@ MCMovementEnd.learningSeed = 0
 # first visit = true; every visit = false
 MCMovementEnd.firstVisit = true
 
+MCMovementEnd.pauseTraining = false
+
 [ EpsilonGreedyBehavior settings ]
 BehaviorPolicy.EpsilonGreedy.epsilon = 1
 BehaviorPolicy.EpsilonGreedy.epsilonDecay = 0.999999

--- a/settings/skripsi/randomsearch-mcn-mc-c-ms@1.cfg
+++ b/settings/skripsi/randomsearch-mcn-mc-c-ms@1.cfg
@@ -114,6 +114,8 @@ MCMovementEnd.agentSpeed = 1
 MCMovementEnd.targetCooldown = 3600
 MCMovementEnd.learningSeed = 0
 
+MCMovementEnd.pauseTraining = false
+
 # first visit = true; every visit = false
 MCMovementEnd.firstVisit = true
 

--- a/settings/skripsi/randomsearch-mcn-mc-p-ms@0.cfg
+++ b/settings/skripsi/randomsearch-mcn-mc-p-ms@0.cfg
@@ -114,6 +114,8 @@ MCMovementEnd.agentSpeed = 1
 MCMovementEnd.targetCooldown = 3600
 MCMovementEnd.learningSeed = 0
 
+MCMovementEnd.pauseTraining = false
+
 # first visit = true; every visit = false
 MCMovementEnd.firstVisit = true
 

--- a/settings/skripsi/randomsearch-mcn-mc-p-ms@1.cfg
+++ b/settings/skripsi/randomsearch-mcn-mc-p-ms@1.cfg
@@ -114,6 +114,8 @@ MCMovementEnd.agentSpeed = 1
 MCMovementEnd.targetCooldown = 3600
 MCMovementEnd.learningSeed = 0
 
+MCMovementEnd.pauseTraining = false
+
 # first visit = true; every visit = false
 MCMovementEnd.firstVisit = true
 

--- a/settings/skripsi/randomsearch-mcn.cfg
+++ b/settings/skripsi/randomsearch-mcn.cfg
@@ -120,6 +120,8 @@ MCMovementEnd.agentSpeed = 1
 MCMovementEnd.targetCooldown = 3600
 MCMovementEnd.learningSeed = 0
 
+MCMovementEnd.pauseTraining = false
+
 # first visit = true; every visit = false
 MCMovementEnd.firstVisit = true
 

--- a/settings/skripsi/randomsearch-qlearn-ql-c-ms@0.cfg
+++ b/settings/skripsi/randomsearch-qlearn-ql-c-ms@0.cfg
@@ -112,6 +112,8 @@ QLearningMovement.agentSpeed = 1
 QLearningMovement.targetCooldown = 3600
 QLearningMovement.learningSeed = 0
 
+QLearningMovement.pauseTraining = false
+
 [ EpsilonGreedyBehavior settings ]
 BehaviorPolicy.EpsilonGreedy.epsilon = 1
 BehaviorPolicy.EpsilonGreedy.epsilonDecay = 0.999999

--- a/settings/skripsi/randomsearch-qlearn-ql-c-ms@1.cfg
+++ b/settings/skripsi/randomsearch-qlearn-ql-c-ms@1.cfg
@@ -112,6 +112,8 @@ QLearningMovement.agentSpeed = 1
 QLearningMovement.targetCooldown = 3600
 QLearningMovement.learningSeed = 0
 
+QLearningMovement.pauseTraining = false
+
 [ EpsilonGreedyBehavior settings ]
 BehaviorPolicy.EpsilonGreedy.epsilon = 1
 BehaviorPolicy.EpsilonGreedy.epsilonDecay = 0.999999

--- a/settings/skripsi/randomsearch-qlearn-ql-p-ms@0.cfg
+++ b/settings/skripsi/randomsearch-qlearn-ql-p-ms@0.cfg
@@ -112,6 +112,8 @@ QLearningMovement.agentSpeed = 1
 QLearningMovement.targetCooldown = 3600
 QLearningMovement.learningSeed = 0
 
+QLearningMovement.pauseTraining = false
+
 [ EpsilonGreedyBehavior settings ]
 BehaviorPolicy.EpsilonGreedy.epsilon = 1
 BehaviorPolicy.EpsilonGreedy.epsilonDecay = 0.999999

--- a/settings/skripsi/randomsearch-qlearn-ql-p-ms@1.cfg
+++ b/settings/skripsi/randomsearch-qlearn-ql-p-ms@1.cfg
@@ -112,6 +112,8 @@ QLearningMovement.agentSpeed = 1
 QLearningMovement.targetCooldown = 3600
 QLearningMovement.learningSeed = 0
 
+QLearningMovement.pauseTraining = false
+
 [ EpsilonGreedyBehavior settings ]
 BehaviorPolicy.EpsilonGreedy.epsilon = 1
 BehaviorPolicy.EpsilonGreedy.epsilonDecay = 0.999999

--- a/settings/skripsi/randomsearch-qlearn.cfg
+++ b/settings/skripsi/randomsearch-qlearn.cfg
@@ -113,6 +113,8 @@ QLearningMovement.agentSpeed = 1
 QLearningMovement.targetCooldown = 3600
 QLearningMovement.learningSeed = 0
 
+QLearningMovement.pauseTraining = false
+
 [ EpsilonGreedyBehavior settings ]
 BehaviorPolicy.EpsilonGreedy.epsilon = 1
 BehaviorPolicy.EpsilonGreedy.epsilonDecay = 0.999999

--- a/src/movement/rl/QLearningMovement.java
+++ b/src/movement/rl/QLearningMovement.java
@@ -70,6 +70,8 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 	public static final String TARGET_COOLDOWN_S = "targetCooldown";
 	public static final String LEARNING_SEED_S = "learningSeed";
 
+	public static final String PAUSE_TRAINING_S = "pauseTraining";
+
 	// [Configuration - Fixed parameters]
 	private final double agentSpeed;
 	/**
@@ -132,6 +134,8 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 	 */
 	public static Random learningRNG;
 
+	public final boolean pauseTraining;
+
 	// static initialization of all movement models' random number generator
 	static {
 		DTNSim.registerForReset(QLearningMovement.class.getCanonicalName());
@@ -179,6 +183,9 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 		// Initialize direction randomly
 		this.direction = rng.nextDouble() * 2 * Math.PI;
 		this.currentPosition = null; // will be initialized on first getPath()
+
+		// Training progress, whether to pauseTraining
+		this.pauseTraining = s.getBoolean(PAUSE_TRAINING_S, false);
 
 		// Re/Initializes episodic persistence
 		EpisodicPersistenceData epd = EpisodicPersistenceManager.loadIfExists();
@@ -240,6 +247,7 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 		this.currentState = proto.currentState;
 		this.currentTrajectorySteps = proto.currentTrajectorySteps;
 		this.direction = proto.direction;
+		this.pauseTraining = proto.pauseTraining;
 
 		if (proto.currentPosition != null) {
 			this.currentPosition = new Coord(proto.currentPosition.getX(), proto.currentPosition.getY());
@@ -344,7 +352,7 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 	@Override
 	public Path getPath() {
 		/* Perform Q-Learning update only if we have previous action */
-		if (prevAction != -1) {
+		if (prevAction != -1 && !pauseTraining) {
 			// to make it easier to understand
 			int s_t = prevState;
 			int a_t = prevAction;


### PR DESCRIPTION
This pull request adds support for pausing Q-learning training in the `QLearningMovement` class. The most important changes are the introduction of a new configuration parameter and the necessary logic to respect this setting during training updates.

**Pause training feature:**

* Added a new configuration parameter `pauseTraining` (`PAUSE_TRAINING_S`) to allow pausing of Q-learning updates via settings. [[1]](diffhunk://#diff-544ea2b804a54b516d14bc67fd88fa2709f8a23a7ca5bcc5575e834d8121cbc1R73-R74) [[2]](diffhunk://#diff-544ea2b804a54b516d14bc67fd88fa2709f8a23a7ca5bcc5575e834d8121cbc1R187-R189)
* Introduced a new instance variable `pauseTraining` and initialized it from settings in the constructor. [[1]](diffhunk://#diff-544ea2b804a54b516d14bc67fd88fa2709f8a23a7ca5bcc5575e834d8121cbc1R137-R138) [[2]](diffhunk://#diff-544ea2b804a54b516d14bc67fd88fa2709f8a23a7ca5bcc5575e834d8121cbc1R187-R189)
* Ensured that the `pauseTraining` value is copied in the copy constructor.
* Modified the Q-learning update in `getPath()` to only proceed if training is not paused (`!pauseTraining`).