### PR TITLE
feat(qlearn): added resetTrajectoryHistory flag which prevents loadin…

### DIFF
--- a/src/movement/rl/QLearningMovement.java
+++ b/src/movement/rl/QLearningMovement.java
@@ -71,6 +71,7 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 	public static final String LEARNING_SEED_S = "learningSeed";
 
 	public static final String PAUSE_TRAINING_S = "pauseTraining";
+	public static final String RESET_TRAJECTORY_HISTORY_S = "resetTrajectoryHistory";
 
 	// [Configuration - Fixed parameters]
 	private final double agentSpeed;
@@ -135,6 +136,7 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 	public static Random learningRNG;
 
 	public final boolean pauseTraining;
+	public final boolean resetTrajectoryHistory;
 
 	// static initialization of all movement models' random number generator
 	static {
@@ -186,6 +188,7 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 
 		// Training progress, whether to pauseTraining
 		this.pauseTraining = s.getBoolean(PAUSE_TRAINING_S, false);
+		this.resetTrajectoryHistory = s.getBoolean(RESET_TRAJECTORY_HISTORY_S, false);
 
 		// Re/Initializes episodic persistence
 		EpisodicPersistenceData epd = EpisodicPersistenceManager.loadIfExists();
@@ -248,6 +251,7 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 		this.currentTrajectorySteps = proto.currentTrajectorySteps;
 		this.direction = proto.direction;
 		this.pauseTraining = proto.pauseTraining;
+		this.resetTrajectoryHistory = proto.resetTrajectoryHistory;
 
 		if (proto.currentPosition != null) {
 			this.currentPosition = new Coord(proto.currentPosition.getX(), proto.currentPosition.getY());
@@ -651,9 +655,12 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 
 		/* Loading trajectory recorder */
 		trajectoryFrequencies.clear();
-		if (epd.trajectoryFrequencies != null) {
-			for (var entry : epd.trajectoryFrequencies.entrySet()) {
-				this.trajectoryFrequencies.put(Integer.valueOf(entry.getKey()), entry.getValue());
+
+		if (!this.resetTrajectoryHistory) {
+			if (epd.trajectoryFrequencies != null) {
+				for (var entry : epd.trajectoryFrequencies.entrySet()) {
+					this.trajectoryFrequencies.put(Integer.valueOf(entry.getKey()), entry.getValue());
+				}
 			}
 		}
 


### PR DESCRIPTION
This pull request adds a new configuration option to the `QLearningMovement` model that allows users to control whether the trajectory history should be reset when loading episodic persistence data. The main changes introduce the `resetTrajectoryHistory` setting and update the relevant constructors and logic to support this behavior.

**New configuration option for trajectory history:**

* Added the `RESET_TRAJECTORY_HISTORY_S` string constant and corresponding `resetTrajectoryHistory` boolean field to `QLearningMovement` to enable controlling trajectory history reset. [[1]](diffhunk://#diff-544ea2b804a54b516d14bc67fd88fa2709f8a23a7ca5bcc5575e834d8121cbc1R74) [[2]](diffhunk://#diff-544ea2b804a54b516d14bc67fd88fa2709f8a23a7ca5bcc5575e834d8121cbc1R139)
* Updated both constructors of `QLearningMovement` to initialize the new `resetTrajectoryHistory` field from settings or from a prototype instance. [[1]](diffhunk://#diff-544ea2b804a54b516d14bc67fd88fa2709f8a23a7ca5bcc5575e834d8121cbc1R191) [[2]](diffhunk://#diff-544ea2b804a54b516d14bc67fd88fa2709f8a23a7ca5bcc5575e834d8121cbc1R254)

**Logic changes for loading trajectory history:**

* Modified the `loadFrom` method to clear and reload `trajectoryFrequencies` only if `resetTrajectoryHistory` is false, effectively allowing the history to be reset when specified.