### PR TITLE
Feat/157 revise starting from state 1 instead of 0   fix trajectory recorder

### DIFF
--- a/settings/demos/randomsearch-lf.cfg
+++ b/settings/demos/randomsearch-lf.cfg
@@ -56,10 +56,13 @@ DecisionEngineRouter.decisionEngine = SearchingAgentRouter
 
 [ Group 2: Searchable Nodes ]
 Group2.groupID = S
-Group2.movementModel = StationaryClustered
+Group2.movementModel = StationaryClusteredOLD
 Group2.cluster = 10, 10
 Group2.sigma = 25.0, 50.0
-Group2.nrofHosts = 101
+# Group2.movementModel = StationaryClustered
+# StationaryClustered.cluster = 10, 10
+# StationaryClustered.sigma = 25.0, 50.0
+Group2.nrofHosts = 100
 Group2.transmitRange = 1
 
 # [ Group 3 ]
@@ -72,7 +75,7 @@ Group2.transmitRange = 1
 [ Movement model settings ]
 # seed for movement models' pseudo random number generator
 #MovementModel.rngSeed = [2, 8372, 98092, 18293, 777]
-MovementModel.rngSeed = 1
+MovementModel.rngSeed = 0
 # World's size (width, height; meters)
 MovementModel.worldSize = 1000, 1000
 # Warmup period (seconds)

--- a/settings/skripsi/randomsearch-lf-episodic-lfe-c-ms@0.cfg
+++ b/settings/skripsi/randomsearch-lf-episodic-lfe-c-ms@0.cfg
@@ -11,7 +11,7 @@ Scenario.endTime = 604800 # 7 days
 Scenario.nrofHostGroups = 2
 
 [ QUICK REFERENCE ]
-; Group2.movementModel = StationaryClustered
+# Group2.movementModel = StationaryClustered
 Group2.movementModel = StationaryClusteredOLD
 Group2.cluster = 10, 10
 Group2.sigma = 25.0, 50.0

--- a/settings/skripsi/randomsearch-lf-episodic-lfe-c-ms@1.cfg
+++ b/settings/skripsi/randomsearch-lf-episodic-lfe-c-ms@1.cfg
@@ -14,7 +14,7 @@ Scenario.nrofHostGroups = 2
 # Group2.movementModel = StationaryClustered
 # MovementModel.rngSeed = 0
 
-; Group2.movementModel = StationaryClustered
+# Group2.movementModel = StationaryClustered
 Group2.movementModel = StationaryClusteredOLD
 Group2.cluster = 10, 10
 Group2.sigma = 25.0, 50.0

--- a/settings/skripsi/randomsearch-mcn-mc-c-ms@0.cfg
+++ b/settings/skripsi/randomsearch-mcn-mc-c-ms@0.cfg
@@ -11,7 +11,7 @@ Scenario.endTime = 604800 # 7 days
 Scenario.nrofHostGroups = 2
 
 [ QUICK REFERENCE ]
-; Group2.movementModel = StationaryClustered
+# Group2.movementModel = StationaryClustered
 Group2.movementModel = StationaryClusteredOLD
 Group2.cluster = 10, 10
 Group2.sigma = 25.0, 50.0

--- a/settings/skripsi/randomsearch-mcn-mc-c-ms@1.cfg
+++ b/settings/skripsi/randomsearch-mcn-mc-c-ms@1.cfg
@@ -14,7 +14,7 @@ Scenario.nrofHostGroups = 2
 # Group2.movementModel = StationaryClustered
 # MovementModel.rngSeed = 0
 
-; Group2.movementModel = StationaryClustered
+# Group2.movementModel = StationaryClustered
 Group2.movementModel = StationaryClusteredOLD
 Group2.cluster = 10, 10
 Group2.sigma = 25.0, 50.0

--- a/settings/skripsi/randomsearch-qlearn-ql-c-ms@0.cfg
+++ b/settings/skripsi/randomsearch-qlearn-ql-c-ms@0.cfg
@@ -11,7 +11,7 @@ Scenario.endTime = 604800 # 7 days
 Scenario.nrofHostGroups = 2
 
 [ QUICK REFERENCE ]
-; Group2.movementModel = StationaryClustered
+# Group2.movementModel = StationaryClustered
 Group2.movementModel = StationaryClusteredOLD
 Group2.cluster = 10, 10
 Group2.sigma = 25.0, 50.0

--- a/settings/skripsi/randomsearch-qlearn-ql-c-ms@1.cfg
+++ b/settings/skripsi/randomsearch-qlearn-ql-c-ms@1.cfg
@@ -14,7 +14,7 @@ Scenario.nrofHostGroups = 2
 # Group2.movementModel = StationaryClustered
 # MovementModel.rngSeed = 0
 
-; Group2.movementModel = StationaryClustered
+# Group2.movementModel = StationaryClustered
 Group2.movementModel = StationaryClusteredOLD
 Group2.cluster = 10, 10
 Group2.sigma = 25.0, 50.0

--- a/src/movement/rl/QLearningMovement.java
+++ b/src/movement/rl/QLearningMovement.java
@@ -496,8 +496,10 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 	 * Records a length value to {@link QLearningMovement#trajectoryFrequencies}.
 	 */
 	private void recordFinishedTrajectory(int length) {
-		if (length < 0) return;
-		else if (length == 0) length = 1;
+		if (length <= 0) {
+			System.out.printf("[%s] Warning: Attempted to record a zero/negative trajectory length: %d. Ignoring.%n",
+				QLearningMovement.class.getCanonicalName(), length);
+		}
 		trajectoryFrequencies.merge(length, 1, Integer::sum);
 	}
 

--- a/src/movement/rl/QLearningMovement.java
+++ b/src/movement/rl/QLearningMovement.java
@@ -177,10 +177,10 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 		this.objectiveFound = new HashMap<>();
 		this.qTable = new HashMap<>();
 		this.prevAction = -1;
-		this.prevState = 0;
+		this.prevState = 1;
 		this.currentAction = -1;
-		this.currentState = 0;
-		this.currentTrajectorySteps = 0;
+		this.currentState = 1;
+		this.currentTrajectorySteps = 1;
 
 		// Initialize direction randomly
 		this.direction = rng.nextDouble() * 2 * Math.PI;
@@ -393,15 +393,15 @@ public class QLearningMovement extends MovementModel implements TrajectoryFreque
 
 		/* Determining the next state s = (n = n + d), based on the previous action */
 		if (currentAction == -1) {
-			/* Start counting from 0 */
-			currentTrajectorySteps = 0;
+			/* Start counting from 1 */
+			currentTrajectorySteps = 1;
 		} else if (currentAction == 0) {
 			/* Continuing straight, increment the step counter */
 			currentTrajectorySteps++;
 		} else if (currentAction == 1) {
-			/* Agent turned, reset n to 0 */
+			/* Agent turned, reset n to 1 */
 			recordFinishedTrajectory(currentTrajectorySteps);
-			currentTrajectorySteps = 0;
+			currentTrajectorySteps = 1;
 		}
 
 		currentState = currentTrajectorySteps;


### PR DESCRIPTION
This pull request updates several configuration files and refines the initialization and trajectory handling logic in the `QLearningMovement` class. The main focus is to standardize the starting state and trajectory step counting to begin from 1 instead of 0, and to improve the handling of invalid trajectory lengths. Additionally, configuration files are updated for consistency and clarity.

### QLearningMovement logic improvements

* Changed the initialization of `prevState`, `currentState`, and `currentTrajectorySteps` to start from 1 instead of 0 in `QLearningMovement.java`, ensuring consistent state representation.
* Updated trajectory step counting in `getPath()` so that counting starts from 1, and resets to 1 (not 0) after a turn.
* Improved `recordFinishedTrajectory()` to ignore and warn on zero or negative trajectory lengths, instead of converting zero to one.

### Configuration and settings adjustments

* Updated comments and uncommented lines related to `Group2.movementModel` in multiple configuration files for clarity and consistency, ensuring the use of `StationaryClusteredOLD` and making the reference to the previous model explicit. [[1]](diffhunk://#diff-6824f663c1439dd614b52ba903b5c275503b0b19f4dff9599960643a943a7f8cL14-R14) [[2]](diffhunk://#diff-2d2416bb2c3f827042283cd54b6e2ce05d69e7d928d8256e792ad32b89202264L17-R17) [[3]](diffhunk://#diff-46b39347b2362741eb149980f694d404c88a9e529d1ad3880adce1fe997c5e7aL14-R14) [[4]](diffhunk://#diff-ecdaebebaf571c65a84436ae47e51efa94ff95664bae0bd7ca2e5e7978a6c6fbL17-R17) [[5]](diffhunk://#diff-85ef16f1cc57b0766ee5fbb8dea5b415101f7ec86aa618de821747c84e6952ebL14-R14) [[6]](diffhunk://#diff-0d8789353bf6342de9b3d5f08d785c95929dce0cd410ad5fd878c544238aaf41L17-R17)
* In `randomsearch-lf.cfg`, changed `Group2.movementModel` to `StationaryClusteredOLD`, adjusted `nrofHosts` from 101 to 100, and set `MovementModel.rngSeed` to 0 for deterministic runs. [[1]](diffhunk://#diff-00ca5f4947a0ce3d4babaf032371e25c9d83d1d7533ef0a62be537008c896c5aL59-R65) [[2]](diffhunk://#diff-00ca5f4947a0ce3d4babaf032371e25c9d83d1d7533ef0a62be537008c896c5aL75-R78)